### PR TITLE
feat: Phase 6 — budget tracking (`ferret budget`)

### DIFF
--- a/src/commands/budget.ts
+++ b/src/commands/budget.ts
@@ -1,5 +1,133 @@
+// `ferret budget` — set / list / track / export monthly budgets per
+// PRD §4.6 and §14.A. Output style is intentionally close to the PRD
+// example so the eyeballed view stays familiar.
+
 import { defineCommand } from 'citty';
-import { notImplemented } from '../lib/errors';
+import pc from 'picocolors';
+import {
+  type BudgetWithProgress,
+  type MonthlyBudgetView,
+  defaultCurrency,
+  exportBudgets,
+  getCurrentMonthBudgets,
+  getHistoricalBudgets,
+  removeBudget,
+  setBudget,
+} from '../db/queries/budgets';
+import { ValidationError } from '../lib/errors';
+import { renderProgressBar } from '../lib/progress-bar';
+
+const BAR_WIDTH = 10;
+
+const CURRENCY_SYMBOLS: Record<string, string> = {
+  GBP: '\u00a3',
+  USD: '$',
+  EUR: '\u20ac',
+};
+
+function symbolFor(currency: string): string {
+  return CURRENCY_SYMBOLS[currency.toUpperCase()] ?? `${currency} `;
+}
+
+function fmtMoney(amount: number, currency: string): string {
+  return `${symbolFor(currency)}${Math.round(amount).toLocaleString('en-GB')}`;
+}
+
+function pad(s: string, n: number): string {
+  return s.length >= n ? s : s + ' '.repeat(n - s.length);
+}
+
+function parseAmount(raw: unknown): number {
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  const n = Number.parseFloat(String(raw));
+  if (!Number.isFinite(n)) {
+    throw new ValidationError(`Amount must be a number, got: ${String(raw)}`);
+  }
+  return n;
+}
+
+function renderCurrentMonthHeader(view: BudgetWithProgress[], now: Date): string {
+  // Use any of the rows for elapsed/total days, or compute from now if empty.
+  let daysElapsed: number;
+  let totalDays: number;
+  const first = view[0];
+  if (first) {
+    daysElapsed = first.daysElapsed;
+    totalDays = first.totalDaysInMonth;
+  } else {
+    totalDays = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 0)).getUTCDate();
+    daysElapsed = Math.max(1, Math.min(totalDays, now.getUTCDate()));
+  }
+  const monthNames = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
+  const label = `${monthNames[now.getUTCMonth()] ?? ''} ${now.getUTCFullYear()}`;
+  const elapsedPct = Math.round((daysElapsed / totalDays) * 100);
+  return `${label} (day ${daysElapsed}/${totalDays}, ${elapsedPct}% elapsed)`;
+}
+
+function renderBudgetRow(b: BudgetWithProgress): string {
+  const bar = renderProgressBar(Math.min(110, b.percent), BAR_WIDTH);
+  const spentStr = fmtMoney(b.spent, b.currency);
+  const limitStr = fmtMoney(b.monthlyAmount, b.currency);
+  const pctStr = `${Math.round(b.percent)}%`;
+
+  let status: string;
+  if (b.percent >= 100) {
+    status = `${pc.red('OVER BUDGET')} \uD83D\uDEA8`;
+  } else if (b.projected > b.monthlyAmount) {
+    status = `projected ${fmtMoney(b.projected, b.currency)} \uD83D\uDEA8`;
+  } else {
+    status = 'on pace';
+  }
+
+  const moneyCol = `${pad(spentStr, 5)} / ${pad(limitStr, 5)}`;
+  return `${pad(b.category, 14)} ${bar}  ${moneyCol}  ${pad(pctStr, 4)} ${status}`;
+}
+
+function renderCurrentMonth(view: BudgetWithProgress[], now: Date): string {
+  const header = renderCurrentMonthHeader(view, now);
+  if (view.length === 0) {
+    return `${header}\n\nNo budgets set. Use \`ferret budget set <category> <amount>\`.`;
+  }
+  const rows = view.map(renderBudgetRow).join('\n');
+  return `${header}\n\n${rows}`;
+}
+
+function renderHistory(views: MonthlyBudgetView[]): string {
+  if (views.length === 0) return 'No history.';
+  const blocks: string[] = [];
+  for (const v of views) {
+    if (v.rows.length === 0) {
+      blocks.push(`${v.label}\n  (no budgets)`);
+      continue;
+    }
+    const lines: string[] = [v.label];
+    for (const r of v.rows) {
+      const bar = renderProgressBar(Math.min(110, r.percent), BAR_WIDTH);
+      const spent = fmtMoney(r.spent, r.currency);
+      const limit = fmtMoney(r.monthlyAmount, r.currency);
+      const pct = `${Math.round(r.percent)}%`;
+      const flag = r.percent >= 100 ? pc.red(' OVER') : '';
+      lines.push(
+        `  ${pad(r.category, 14)} ${bar}  ${pad(spent, 5)} / ${pad(limit, 5)}  ${pad(pct, 4)}${flag}`,
+      );
+    }
+    blocks.push(lines.join('\n'));
+  }
+  return blocks.join('\n\n');
+}
 
 export default defineCommand({
   meta: { name: 'budget', description: 'Manage and view monthly budgets' },
@@ -8,10 +136,16 @@ export default defineCommand({
       meta: { name: 'set', description: 'Set or update a category budget' },
       args: {
         category: { type: 'positional', description: 'Category', required: true },
-        amount: { type: 'positional', description: 'Monthly amount', required: true },
+        amount: { type: 'positional', description: 'Monthly amount (must be > 0)', required: true },
       },
-      run() {
-        notImplemented('budget set', 7);
+      run({ args }) {
+        const category = String(args.category);
+        const amount = parseAmount(args.amount);
+        const currency = defaultCurrency();
+        const saved = setBudget(category, amount, currency);
+        process.stdout.write(
+          `set budget: ${saved.category} ${fmtMoney(saved.monthlyAmount, saved.currency)} / month\n`,
+        );
       },
     }),
     rm: defineCommand({
@@ -19,27 +153,46 @@ export default defineCommand({
       args: {
         category: { type: 'positional', description: 'Category', required: true },
       },
-      run() {
-        notImplemented('budget rm', 7);
+      run({ args }) {
+        const category = String(args.category);
+        const removed = removeBudget(category);
+        if (!removed) {
+          throw new ValidationError(`No budget set for category: ${category}`);
+        }
+        process.stdout.write(`removed budget: ${category}\n`);
       },
     }),
     history: defineCommand({
       meta: { name: 'history', description: 'Month-over-month view' },
       args: {
-        months: { type: 'string', description: 'Number of months back' },
+        months: { type: 'string', description: 'Number of months back (default 6)' },
       },
-      run() {
-        notImplemented('budget history', 7);
+      run({ args }) {
+        const raw = args.months ? Number.parseInt(String(args.months), 10) : 6;
+        if (!Number.isFinite(raw) || raw <= 0) {
+          throw new ValidationError(`--months must be a positive integer, got: ${args.months}`);
+        }
+        const views = getHistoricalBudgets(raw);
+        process.stdout.write(`${renderHistory(views)}\n`);
       },
     }),
     export: defineCommand({
       meta: { name: 'export', description: 'Export budgets as JSON' },
       run() {
-        notImplemented('budget export', 7);
+        const rows = exportBudgets();
+        process.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
       },
     }),
   },
-  run() {
-    notImplemented('budget', 7);
+  // citty 0.1.6 invokes the parent `run` even after a subcommand has run, so
+  // we have to detect that case and bail. The subcommand name (if any) shows
+  // up as the first positional in `rawArgs`.
+  run({ rawArgs }) {
+    const SUBCOMMANDS = new Set(['set', 'rm', 'history', 'export']);
+    const first = rawArgs.find((a) => !a.startsWith('-'));
+    if (first && SUBCOMMANDS.has(first)) return;
+    const now = new Date();
+    const view = getCurrentMonthBudgets(now);
+    process.stdout.write(`${renderCurrentMonth(view, now)}\n`);
   },
 });

--- a/src/commands/budget.ts
+++ b/src/commands/budget.ts
@@ -11,6 +11,7 @@ import {
   exportBudgets,
   getCurrentMonthBudgets,
   getHistoricalBudgets,
+  monthLabel,
   removeBudget,
   setBudget,
 } from '../db/queries/budgets';
@@ -33,15 +34,37 @@ function fmtMoney(amount: number, currency: string): string {
   return `${symbolFor(currency)}${Math.round(amount).toLocaleString('en-GB')}`;
 }
 
+// Width measured in Unicode code points rather than UTF-16 code units so
+// surrogate-pair glyphs (e.g. emoji currency markers) don't throw the column
+// alignment off. This is still not grapheme-cluster correct, but matches
+// what a fixed-width terminal sees for the symbols we currently support
+// (£/$/€ are all single code points).
+function visualLength(s: string): number {
+  let n = 0;
+  for (const _ of s) n++;
+  return n;
+}
+
 function pad(s: string, n: number): string {
-  return s.length >= n ? s : s + ' '.repeat(n - s.length);
+  const len = visualLength(s);
+  return len >= n ? s : s + ' '.repeat(n - len);
 }
 
 function parseAmount(raw: unknown): number {
-  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
-  const n = Number.parseFloat(String(raw));
-  if (!Number.isFinite(n)) {
-    throw new ValidationError(`Amount must be a number, got: ${String(raw)}`);
+  let n: number;
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    n = raw;
+  } else {
+    n = Number.parseFloat(String(raw));
+    if (!Number.isFinite(n)) {
+      throw new ValidationError(`Amount must be a number, got: ${String(raw)}`);
+    }
+  }
+  // Reject zero / negative early: budgets are always positive monthly limits.
+  // The downstream setBudget check would also catch this, but the message
+  // is more useful here at the input boundary.
+  if (n <= 0) {
+    throw new ValidationError(`Amount must be greater than 0, got: ${n}`);
   }
   return n;
 }
@@ -58,23 +81,8 @@ function renderCurrentMonthHeader(view: BudgetWithProgress[], now: Date): string
     totalDays = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 0)).getUTCDate();
     daysElapsed = Math.max(1, Math.min(totalDays, now.getUTCDate()));
   }
-  const monthNames = [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December',
-  ];
-  const label = `${monthNames[now.getUTCMonth()] ?? ''} ${now.getUTCFullYear()}`;
   const elapsedPct = Math.round((daysElapsed / totalDays) * 100);
-  return `${label} (day ${daysElapsed}/${totalDays}, ${elapsedPct}% elapsed)`;
+  return `${monthLabel(now)} (day ${daysElapsed}/${totalDays}, ${elapsedPct}% elapsed)`;
 }
 
 function renderBudgetRow(b: BudgetWithProgress): string {
@@ -180,7 +188,12 @@ export default defineCommand({
       meta: { name: 'export', description: 'Export budgets as JSON' },
       run() {
         const rows = exportBudgets();
-        process.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
+        // Always emit valid JSON, even when zero budgets are set. An empty
+        // array serialises to "[]" which is what import-side consumers
+        // expect (and is what JSON.stringify already produces for []), so
+        // the explicit branch is just for clarity / future maintainers.
+        const payload = rows.length === 0 ? '[]' : JSON.stringify(rows, null, 2);
+        process.stdout.write(`${payload}\n`);
       },
     }),
   },

--- a/src/db/queries/budgets.ts
+++ b/src/db/queries/budgets.ts
@@ -1,0 +1,226 @@
+// Budget query helpers used by `ferret budget`.
+//
+// Spending math:
+//   - `transactions.amount` is signed: negative = outflow (per schema).
+//   - "Spent" for a budget over a window = SUM(ABS(amount)) WHERE amount < 0
+//     AND category matches AND timestamp falls in the window.
+//
+// All month windows are computed in UTC to avoid local-DST drift. We don't
+// rely on src/lib/dates.ts here (Phase 3 owns it and is in flight); the
+// helpers below are intentionally minimal and local.
+
+import { randomUUID } from 'node:crypto';
+import { and, eq, gte, lt, sql } from 'drizzle-orm';
+import { loadConfig } from '../../lib/config';
+import { ValidationError } from '../../lib/errors';
+import type { Budget } from '../../types/domain';
+import { getDb } from '../client';
+import { budgets, categories, transactions } from '../schema';
+
+export interface BudgetWithProgress {
+  category: string;
+  monthlyAmount: number;
+  currency: string;
+  spent: number;
+  percent: number;
+  projected: number;
+  daysElapsed: number;
+  totalDaysInMonth: number;
+}
+
+export interface MonthlyBudgetRow {
+  category: string;
+  monthlyAmount: number;
+  currency: string;
+  spent: number;
+  percent: number;
+}
+
+export interface MonthlyBudgetView {
+  year: number;
+  month: number; // 1-12
+  label: string; // e.g. "April 2026"
+  rows: MonthlyBudgetRow[];
+}
+
+const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+] as const;
+
+function startOfMonthUTC(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1, 0, 0, 0, 0));
+}
+
+function startOfNextMonthUTC(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 1, 0, 0, 0, 0));
+}
+
+function daysInMonthUTC(d: Date): number {
+  // Day 0 of next month = last day of this month.
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0)).getUTCDate();
+}
+
+function monthLabel(d: Date): string {
+  const name = MONTH_NAMES[d.getUTCMonth()] ?? '';
+  return `${name} ${d.getUTCFullYear()}`;
+}
+
+// SQL: SUM of absolute outflow for a category over [from, to).
+function sumOutflow(category: string, from: Date, to: Date): number {
+  const { db } = getDb();
+  const rows = db
+    .select({
+      total: sql<number | null>`COALESCE(SUM(ABS(${transactions.amount})), 0)`,
+    })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.category, category),
+        sql`${transactions.amount} < 0`,
+        gte(transactions.timestamp, from),
+        lt(transactions.timestamp, to),
+      ),
+    )
+    .all();
+  const first = rows[0];
+  const total = first?.total;
+  return typeof total === 'number' ? total : 0;
+}
+
+export function setBudget(category: string, monthlyAmount: number, currency: string): Budget {
+  if (!Number.isFinite(monthlyAmount) || monthlyAmount <= 0) {
+    throw new ValidationError(`Budget amount must be a positive number, got: ${monthlyAmount}`);
+  }
+  if (!category || !category.trim()) {
+    throw new ValidationError('Category name is required');
+  }
+
+  const { db } = getDb();
+  const cat = db
+    .select({ name: categories.name })
+    .from(categories)
+    .where(eq(categories.name, category))
+    .all();
+  if (cat.length === 0) {
+    throw new ValidationError(
+      `Unknown category: "${category}". Run \`ferret tag\` to see available categories.`,
+    );
+  }
+
+  const existing = db.select().from(budgets).where(eq(budgets.category, category)).all();
+  const first = existing[0];
+  if (first) {
+    db.update(budgets).set({ monthlyAmount, currency }).where(eq(budgets.id, first.id)).run();
+    return { ...first, monthlyAmount, currency };
+  }
+
+  const row: Budget = {
+    id: randomUUID(),
+    category,
+    monthlyAmount,
+    currency,
+    startDate: startOfMonthUTC(new Date()),
+    endDate: null,
+  };
+  db.insert(budgets).values(row).run();
+  return row;
+}
+
+export function removeBudget(category: string): boolean {
+  const { db } = getDb();
+  const existing = db.select().from(budgets).where(eq(budgets.category, category)).all();
+  if (existing.length === 0) return false;
+  db.delete(budgets).where(eq(budgets.category, category)).run();
+  return true;
+}
+
+export function getCurrentMonthBudgets(now: Date = new Date()): BudgetWithProgress[] {
+  const { db } = getDb();
+  const all = db.select().from(budgets).all();
+
+  const monthStart = startOfMonthUTC(now);
+  const monthEnd = startOfNextMonthUTC(now);
+  const totalDays = daysInMonthUTC(now);
+  // Day-of-month treated as elapsed days (current day counts as in-progress).
+  // Clamp to [1, totalDays] so the projection math never divides by zero.
+  const daysElapsed = Math.max(1, Math.min(totalDays, now.getUTCDate()));
+
+  const out: BudgetWithProgress[] = [];
+  for (const b of all) {
+    const spent = sumOutflow(b.category, monthStart, monthEnd);
+    const percent = b.monthlyAmount > 0 ? (spent / b.monthlyAmount) * 100 : 0;
+    const projected = (spent / daysElapsed) * totalDays;
+    out.push({
+      category: b.category,
+      monthlyAmount: b.monthlyAmount,
+      currency: b.currency,
+      spent,
+      percent,
+      projected,
+      daysElapsed,
+      totalDaysInMonth: totalDays,
+    });
+  }
+  return out;
+}
+
+export function getHistoricalBudgets(months: number, now: Date = new Date()): MonthlyBudgetView[] {
+  if (!Number.isFinite(months) || months <= 0) {
+    throw new ValidationError(`months must be a positive integer, got: ${months}`);
+  }
+  const { db } = getDb();
+  const all = db.select().from(budgets).all();
+
+  const result: MonthlyBudgetView[] = [];
+  // Walk from oldest to newest so output reads chronologically.
+  for (let offset = months - 1; offset >= 0; offset--) {
+    const ref = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset, 1));
+    const monthStart = startOfMonthUTC(ref);
+    const monthEnd = startOfNextMonthUTC(ref);
+    const rows: MonthlyBudgetRow[] = [];
+    for (const b of all) {
+      const spent = sumOutflow(b.category, monthStart, monthEnd);
+      const percent = b.monthlyAmount > 0 ? (spent / b.monthlyAmount) * 100 : 0;
+      rows.push({
+        category: b.category,
+        monthlyAmount: b.monthlyAmount,
+        currency: b.currency,
+        spent,
+        percent,
+      });
+    }
+    result.push({
+      year: ref.getUTCFullYear(),
+      month: ref.getUTCMonth() + 1,
+      label: monthLabel(ref),
+      rows,
+    });
+  }
+  return result;
+}
+
+export function exportBudgets(): Budget[] {
+  const { db } = getDb();
+  return db.select().from(budgets).all();
+}
+
+// Convenience accessor for the configured currency. Kept here so the command
+// layer doesn't have to thread it through.
+export function defaultCurrency(): string {
+  try {
+    return loadConfig().currency;
+  } catch {
+    return 'GBP';
+  }
+}

--- a/src/db/queries/budgets.ts
+++ b/src/db/queries/budgets.ts
@@ -71,31 +71,85 @@ function daysInMonthUTC(d: Date): number {
   return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0)).getUTCDate();
 }
 
-function monthLabel(d: Date): string {
+// Exported so the command layer can reuse the same month formatting
+// without duplicating the MONTH_NAMES array.
+export function monthLabel(d: Date): string {
   const name = MONTH_NAMES[d.getUTCMonth()] ?? '';
   return `${name} ${d.getUTCFullYear()}`;
 }
 
-// SQL: SUM of absolute outflow for a category over [from, to).
-function sumOutflow(category: string, from: Date, to: Date): number {
+// SQL: SUM of absolute outflow grouped by category over [from, to).
+// Returns a Map keyed by category for O(1) lookup. The COALESCE on the
+// aggregate guarantees a non-null number at runtime, so the column is typed
+// `sql<number>` (not `number | null`) to match reality.
+function sumOutflowByCategory(from: Date, to: Date): Map<string, number> {
   const { db } = getDb();
   const rows = db
     .select({
-      total: sql<number | null>`COALESCE(SUM(ABS(${transactions.amount})), 0)`,
+      category: transactions.category,
+      total: sql<number>`COALESCE(SUM(ABS(${transactions.amount})), 0)`,
     })
     .from(transactions)
     .where(
       and(
-        eq(transactions.category, category),
         sql`${transactions.amount} < 0`,
         gte(transactions.timestamp, from),
         lt(transactions.timestamp, to),
       ),
     )
+    .groupBy(transactions.category)
     .all();
-  const first = rows[0];
-  const total = first?.total;
-  return typeof total === 'number' ? total : 0;
+  const map = new Map<string, number>();
+  for (const r of rows) {
+    if (r.category == null) continue;
+    map.set(r.category, typeof r.total === 'number' ? r.total : 0);
+  }
+  return map;
+}
+
+// SQL: SUM of absolute outflow grouped by (category, year-month) across the
+// supplied window [from, to). Returns a nested map: yearMonthKey -> category ->
+// spent. yearMonthKey is "YYYY-MM" computed in UTC to mirror the JS month math.
+function sumOutflowByCategoryAndMonth(from: Date, to: Date): Map<string, Map<string, number>> {
+  const { db } = getDb();
+  // SQLite stores timestamps as unix seconds (integer mode 'timestamp'); use
+  // strftime over datetime(unixepoch) to bucket by UTC year-month.
+  const rows = db
+    .select({
+      category: transactions.category,
+      yearMonth: sql<string>`strftime('%Y-%m', datetime(${transactions.timestamp}, 'unixepoch'))`,
+      total: sql<number>`COALESCE(SUM(ABS(${transactions.amount})), 0)`,
+    })
+    .from(transactions)
+    .where(
+      and(
+        sql`${transactions.amount} < 0`,
+        gte(transactions.timestamp, from),
+        lt(transactions.timestamp, to),
+      ),
+    )
+    .groupBy(
+      sql`strftime('%Y-%m', datetime(${transactions.timestamp}, 'unixepoch'))`,
+      transactions.category,
+    )
+    .all();
+  const out = new Map<string, Map<string, number>>();
+  for (const r of rows) {
+    if (r.category == null || r.yearMonth == null) continue;
+    let inner = out.get(r.yearMonth);
+    if (!inner) {
+      inner = new Map<string, number>();
+      out.set(r.yearMonth, inner);
+    }
+    inner.set(r.category, typeof r.total === 'number' ? r.total : 0);
+  }
+  return out;
+}
+
+function yearMonthKey(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = d.getUTCMonth() + 1;
+  return `${y}-${m < 10 ? `0${m}` : m}`;
 }
 
 export function setBudget(category: string, monthlyAmount: number, currency: string): Budget {
@@ -156,9 +210,12 @@ export function getCurrentMonthBudgets(now: Date = new Date()): BudgetWithProgre
   // Clamp to [1, totalDays] so the projection math never divides by zero.
   const daysElapsed = Math.max(1, Math.min(totalDays, now.getUTCDate()));
 
+  // Single grouped query covers every budget category at once (was N+1).
+  const spentByCategory = sumOutflowByCategory(monthStart, monthEnd);
+
   const out: BudgetWithProgress[] = [];
   for (const b of all) {
-    const spent = sumOutflow(b.category, monthStart, monthEnd);
+    const spent = spentByCategory.get(b.category) ?? 0;
     const percent = b.monthlyAmount > 0 ? (spent / b.monthlyAmount) * 100 : 0;
     const projected = (spent / daysElapsed) * totalDays;
     out.push({
@@ -182,15 +239,21 @@ export function getHistoricalBudgets(months: number, now: Date = new Date()): Mo
   const { db } = getDb();
   const all = db.select().from(budgets).all();
 
+  // Bound the query window once for the whole history span, then pivot in JS.
+  // Was: months * budgets COUNT separate SUM queries.
+  const oldestRef = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - (months - 1), 1));
+  const windowStart = startOfMonthUTC(oldestRef);
+  const windowEnd = startOfNextMonthUTC(now);
+  const spentByMonth = sumOutflowByCategoryAndMonth(windowStart, windowEnd);
+
   const result: MonthlyBudgetView[] = [];
   // Walk from oldest to newest so output reads chronologically.
   for (let offset = months - 1; offset >= 0; offset--) {
     const ref = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset, 1));
-    const monthStart = startOfMonthUTC(ref);
-    const monthEnd = startOfNextMonthUTC(ref);
+    const monthMap = spentByMonth.get(yearMonthKey(ref));
     const rows: MonthlyBudgetRow[] = [];
     for (const b of all) {
-      const spent = sumOutflow(b.category, monthStart, monthEnd);
+      const spent = monthMap?.get(b.category) ?? 0;
       const percent = b.monthlyAmount > 0 ? (spent / b.monthlyAmount) * 100 : 0;
       rows.push({
         category: b.category,

--- a/src/lib/progress-bar.ts
+++ b/src/lib/progress-bar.ts
@@ -1,0 +1,25 @@
+// ASCII progress bar renderer used by `ferret budget`. Style matches the
+// PRD §14.A example (filled = U+2588 FULL BLOCK, empty = U+2591 LIGHT SHADE).
+//
+// Behaviour:
+//   - percent is clamped to [0, 100] for the *visual* fill so a 124%
+//     bar still fits in `width` cells (the over-budget state is signalled
+//     elsewhere by the OVER BUDGET label).
+//   - filled cells = round(width * percent/100), but never less than 1
+//     when percent > 0 (so 1% renders as a single block, not empty).
+//   - width is the total cell count.
+
+const FILLED = '\u2588'; // full block
+const EMPTY = '\u2591'; // light shade
+
+export function renderProgressBar(percent: number, width = 12): string {
+  if (!Number.isFinite(percent)) return EMPTY.repeat(width);
+  if (width <= 0) return '';
+
+  const visualPct = Math.max(0, Math.min(100, percent));
+  let filled = Math.round((width * visualPct) / 100);
+  if (visualPct > 0 && filled === 0) filled = 1;
+  if (visualPct >= 100) filled = width;
+  const empty = width - filled;
+  return `${FILLED.repeat(filled)}${EMPTY.repeat(empty)}`;
+}

--- a/tests/unit/budgets.test.ts
+++ b/tests/unit/budgets.test.ts
@@ -1,0 +1,161 @@
+import { afterAll, beforeAll, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const tmp = mkdtempSync(join(tmpdir(), 'ferret-budgets-'));
+process.env.HOME = tmp;
+
+// Use a fixed "now" so window math is deterministic. Choose mid-month so
+// projection is non-trivial. April 2026, day 19/30, 63% elapsed.
+const NOW = new Date(Date.UTC(2026, 3, 19, 12, 0, 0));
+
+// Helper: insert a transaction directly via raw sqlite. Amount negative = outflow.
+async function seedTxn(
+  id: string,
+  category: string,
+  amount: number,
+  daysAgoFromNow: number,
+): Promise<void> {
+  const { getDb } = await import('../../src/db/client');
+  const { raw } = getDb();
+  const ts = Math.floor((NOW.getTime() - daysAgoFromNow * 86_400_000) / 1000);
+  raw
+    .prepare(
+      `INSERT OR IGNORE INTO transactions
+       (id, account_id, timestamp, amount, currency, description, merchant_name,
+        transaction_type, category, category_source, provider_category, running_balance,
+        is_pending, metadata, created_at, updated_at)
+       VALUES (?, 'test-acct', ?, ?, 'GBP', ?, ?, ?, ?, 'manual', NULL, NULL, 0, NULL, ?, ?)`,
+    )
+    .run(id, ts, amount, `seed ${id}`, category, amount < 0 ? 'DEBIT' : 'CREDIT', category, ts, ts);
+}
+
+beforeAll(async () => {
+  // Boot DB + seed categories via init.
+  const initMod = await import('../../src/commands/init');
+  const cmd = initMod.default as { run: (ctx?: unknown) => unknown };
+  await cmd.run();
+
+  // Need a connection + account for the FK on transactions.
+  const { getDb } = await import('../../src/db/client');
+  const { raw } = getDb();
+  raw
+    .prepare(
+      `INSERT OR IGNORE INTO connections
+       (id, provider_id, provider_name, created_at, expires_at, status, last_synced_at)
+       VALUES ('test-conn', 'manual', 'Test', ?, ?, 'active', ?)`,
+    )
+    .run(
+      Math.floor(NOW.getTime() / 1000),
+      Math.floor((NOW.getTime() + 90 * 86_400_000) / 1000),
+      Math.floor(NOW.getTime() / 1000),
+    );
+  raw
+    .prepare(
+      `INSERT OR IGNORE INTO accounts
+       (id, connection_id, account_type, display_name, currency, balance_available,
+        balance_current, balance_updated_at, is_manual)
+       VALUES ('test-acct', 'test-conn', 'TRANSACTION', 'Test', 'GBP', 0, 0, ?, 1)`,
+    )
+    .run(Math.floor(NOW.getTime() / 1000));
+
+  // Current month (April 2026): Groceries 100 + 50 = 150 outflow, plus a +20
+  // refund (positive amount) that should be ignored.
+  await seedTxn('cur-grc-1', 'Groceries', -100, 1);
+  await seedTxn('cur-grc-2', 'Groceries', -50, 5);
+  await seedTxn('cur-grc-refund', 'Groceries', 20, 2);
+  // Eating Out — 80 spent, no budget set initially (we'll only budget Groceries
+  // and Transport so we can verify "no row when no budget").
+  await seedTxn('cur-eat-1', 'Eating Out', -80, 3);
+  // Transport — 60 spent (under £180 budget set in test).
+  await seedTxn('cur-trn-1', 'Transport', -60, 4);
+
+  // Previous month (March 2026): Groceries 200 spent, Transport 30 spent.
+  // Day 50 ago from Apr 19 = Feb 28; day 35 = Mar 15; day 25 = Mar 25.
+  await seedTxn('prv-grc-1', 'Groceries', -200, 35);
+  await seedTxn('prv-trn-1', 'Transport', -30, 25);
+});
+
+afterAll(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+test('setBudget validates amount > 0', async () => {
+  const { setBudget } = await import('../../src/db/queries/budgets');
+  expect(() => setBudget('Groceries', 0, 'GBP')).toThrow();
+  expect(() => setBudget('Groceries', -10, 'GBP')).toThrow();
+});
+
+test('setBudget rejects unknown category', async () => {
+  const { setBudget } = await import('../../src/db/queries/budgets');
+  expect(() => setBudget('NotARealCategory', 100, 'GBP')).toThrow();
+});
+
+test('setBudget inserts then updates idempotently', async () => {
+  const { setBudget, exportBudgets } = await import('../../src/db/queries/budgets');
+  setBudget('Groceries', 200, 'GBP');
+  setBudget('Transport', 180, 'GBP');
+  const a = exportBudgets().find((b) => b.category === 'Groceries');
+  expect(a?.monthlyAmount).toBe(200);
+  // Update the same category — must not duplicate.
+  setBudget('Groceries', 250, 'GBP');
+  const all = exportBudgets();
+  const grc = all.filter((b) => b.category === 'Groceries');
+  expect(grc.length).toBe(1);
+  expect(grc[0]?.monthlyAmount).toBe(250);
+});
+
+test('getCurrentMonthBudgets returns spent/percent/projected for active budgets', async () => {
+  const { getCurrentMonthBudgets } = await import('../../src/db/queries/budgets');
+  const view = getCurrentMonthBudgets(NOW);
+  // Only categories with a budget should appear: Groceries + Transport.
+  const cats = view.map((v) => v.category).sort();
+  expect(cats).toEqual(['Groceries', 'Transport']);
+
+  const grc = view.find((v) => v.category === 'Groceries');
+  expect(grc).toBeDefined();
+  if (!grc) return;
+  // Spent = 100 + 50 = 150 (refund of +20 ignored).
+  expect(grc.spent).toBeCloseTo(150, 5);
+  // Percent = 150 / 250 * 100 = 60.
+  expect(grc.percent).toBeCloseTo(60, 5);
+  // Projected = (150 / 19) * 30 ≈ 236.84.
+  expect(grc.projected).toBeCloseTo((150 / 19) * 30, 5);
+  expect(grc.daysElapsed).toBe(19);
+  expect(grc.totalDaysInMonth).toBe(30);
+
+  const trn = view.find((v) => v.category === 'Transport');
+  expect(trn).toBeDefined();
+  if (!trn) return;
+  expect(trn.spent).toBeCloseTo(60, 5);
+  expect(trn.percent).toBeCloseTo((60 / 180) * 100, 5);
+});
+
+test('getHistoricalBudgets(2) returns oldest-to-newest with correct rows', async () => {
+  const { getHistoricalBudgets } = await import('../../src/db/queries/budgets');
+  const months = getHistoricalBudgets(2, NOW);
+  expect(months.length).toBe(2);
+
+  const [mar, apr] = months;
+  expect(mar?.year).toBe(2026);
+  expect(mar?.month).toBe(3);
+  expect(apr?.year).toBe(2026);
+  expect(apr?.month).toBe(4);
+
+  const marGrc = mar?.rows.find((r) => r.category === 'Groceries');
+  expect(marGrc?.spent).toBeCloseTo(200, 5);
+  const marTrn = mar?.rows.find((r) => r.category === 'Transport');
+  expect(marTrn?.spent).toBeCloseTo(30, 5);
+
+  const aprGrc = apr?.rows.find((r) => r.category === 'Groceries');
+  expect(aprGrc?.spent).toBeCloseTo(150, 5);
+});
+
+test('removeBudget returns false for unknown, true for existing', async () => {
+  const { removeBudget, exportBudgets } = await import('../../src/db/queries/budgets');
+  expect(removeBudget('NoSuchCategory')).toBe(false);
+  expect(removeBudget('Transport')).toBe(true);
+  const after = exportBudgets().map((b) => b.category);
+  expect(after).not.toContain('Transport');
+});

--- a/tests/unit/progress-bar.test.ts
+++ b/tests/unit/progress-bar.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from 'bun:test';
+import { renderProgressBar } from '../../src/lib/progress-bar';
+
+const FILLED = '\u2588';
+const EMPTY = '\u2591';
+
+test('0% renders as fully empty', () => {
+  expect(renderProgressBar(0, 10)).toBe(EMPTY.repeat(10));
+});
+
+test('50% renders as half filled', () => {
+  const bar = renderProgressBar(50, 10);
+  expect(bar.length).toBe(10);
+  expect(bar).toBe(`${FILLED.repeat(5)}${EMPTY.repeat(5)}`);
+});
+
+test('100% renders as fully filled', () => {
+  expect(renderProgressBar(100, 10)).toBe(FILLED.repeat(10));
+});
+
+test('over 100% (124%) clamps the visual fill to width', () => {
+  const bar = renderProgressBar(124, 10);
+  expect(bar.length).toBe(10);
+  expect(bar).toBe(FILLED.repeat(10));
+});
+
+test('default width is 12', () => {
+  expect(renderProgressBar(0).length).toBe(12);
+  expect(renderProgressBar(100).length).toBe(12);
+});
+
+test('tiny non-zero percent still shows at least one filled cell', () => {
+  const bar = renderProgressBar(1, 10);
+  expect(bar.startsWith(FILLED)).toBe(true);
+});


### PR DESCRIPTION
Closes #7.

## Summary

Implements Phase 6 of the Ferret CLI: monthly budget tracking via `ferret budget`. Per PRD §4.6 and §14.A.

- `ferret budget set <category> <amount>` — set/update a per-category monthly cap (validates amount > 0 and category exists in the seeded `categories` taxonomy).
- `ferret budget rm <category>` — remove a budget.
- `ferret budget` (default) — current-month progress view: ASCII bars (`█████░░░░░`), spent / limit, percent, plus end-of-month projection. Over-budget rows are highlighted red ("OVER BUDGET 🚨"); rows whose pace projects an over-spend show "projected £X 🚨"; otherwise "on pace".
- `ferret budget history --months <n>` — month-over-month rollup (default 6 months, oldest first).
- `ferret budget export` — JSON dump of the budgets table.

Spend math: `SUM(ABS(amount)) WHERE amount < 0` for the budget's category, scoped to a UTC month window. Refunds (positive amounts) are intentionally excluded.

## Files

- `src/db/queries/budgets.ts` (new) — `setBudget`, `removeBudget`, `getCurrentMonthBudgets`, `getHistoricalBudgets`, `exportBudgets`.
- `src/lib/progress-bar.ts` (new) — `renderProgressBar(percent, width=12)`.
- `src/commands/budget.ts` — replaces the stub with the full citty subcommand tree.
- `tests/unit/budgets.test.ts`, `tests/unit/progress-bar.test.ts` — new suites.

Did **not** touch `src/lib/dates.ts` or `src/lib/format.ts` (Phase 3, in flight) — month-window helpers live locally inside the queries module and can be refactored once Phase 3 lands.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run check` clean
- [x] `bun test` — 12 new tests pass (1 unrelated pre-existing schema test failure caused by module-level HOME caching across test files; reproduces on `main`)
- [x] E2E:
  ```
  HOME=$(mktemp -d) bash -c '
    bun run src/cli.ts init
    bun run scripts/dev-seed.ts
    bun run src/cli.ts budget set Groceries 200
    bun run src/cli.ts budget
    bun run src/cli.ts budget history --months 3
    bun run src/cli.ts budget export
  '
  ```
- [x] `bun run src/cli.ts budget --help` lists the four subcommands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)