### PR TITLE
feat: Phase 1 — TrueLayer OAuth (link/unlink/connections)

### DIFF
--- a/src/commands/connections.ts
+++ b/src/commands/connections.ts
@@ -1,9 +1,77 @@
+// `ferret connections` — list every known connection with status, expiry,
+// and last sync. Per PRD §4.1, expiry within 7 days is highlighted yellow.
+
 import { defineCommand } from 'citty';
-import { notImplemented } from '../lib/errors';
+import Table from 'cli-table3';
+import { desc } from 'drizzle-orm';
+import pc from 'picocolors';
+import { getDb } from '../db/client';
+import { connections } from '../db/schema';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function formatExpiryCountdown(expiresAt: Date | null, now: number): string {
+  if (!expiresAt) return '-';
+  const deltaMs = expiresAt.getTime() - now;
+  const days = Math.round(deltaMs / DAY_MS);
+  if (deltaMs <= 0) return pc.red(`expired ${Math.abs(days)}d ago`);
+  const text = `${days}d (${expiresAt.toISOString().slice(0, 10)})`;
+  if (days < 7) return pc.yellow(text);
+  return text;
+}
+
+function formatLastSync(ts: Date | null, now: number): string {
+  if (!ts) return pc.dim('never');
+  const deltaMs = now - ts.getTime();
+  const minutes = Math.round(deltaMs / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
+function formatStatus(status: string): string {
+  switch (status) {
+    case 'active':
+      return pc.green(status);
+    case 'expired':
+      return pc.red(status);
+    case 'revoked':
+      return pc.dim(status);
+    case 'needs_reauth':
+      return pc.yellow(status);
+    default:
+      return status;
+  }
+}
 
 export default defineCommand({
-  meta: { name: 'connections', description: 'List active bank connections' },
+  meta: { name: 'connections', description: 'List bank connections' },
   run() {
-    notImplemented('connections', 2);
+    const { db } = getDb();
+    const rows = db.select().from(connections).orderBy(desc(connections.createdAt)).all();
+
+    const table = new Table({
+      head: ['ID', 'Provider', 'Status', 'Expires', 'Last sync'],
+      style: { head: ['bold'], border: [] },
+    });
+
+    const now = Date.now();
+    for (const r of rows) {
+      table.push([
+        r.id,
+        r.providerName,
+        formatStatus(r.status),
+        formatExpiryCountdown(r.expiresAt, now),
+        formatLastSync(r.lastSyncedAt, now),
+      ]);
+    }
+
+    process.stdout.write(`${table.toString()}\n`);
+    if (rows.length === 0) {
+      process.stdout.write(pc.dim('No connections. Run `ferret link` to add one.\n'));
+    }
   },
 });

--- a/src/commands/connections.ts
+++ b/src/commands/connections.ts
@@ -53,6 +53,11 @@ export default defineCommand({
     const { db } = getDb();
     const rows = db.select().from(connections).orderBy(desc(connections.createdAt)).all();
 
+    if (rows.length === 0) {
+      process.stdout.write(pc.dim('No connections. Run `ferret link` to add one.\n'));
+      return;
+    }
+
     const table = new Table({
       head: ['ID', 'Provider', 'Status', 'Expires', 'Last sync'],
       style: { head: ['bold'], border: [] },
@@ -70,8 +75,5 @@ export default defineCommand({
     }
 
     process.stdout.write(`${table.toString()}\n`);
-    if (rows.length === 0) {
-      process.stdout.write(pc.dim('No connections. Run `ferret link` to add one.\n'));
-    }
   },
 });

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -1,12 +1,206 @@
+// `ferret link` — full TrueLayer OAuth flow per PRD §4.1 + §8.1.
+//
+// Steps:
+//   1. Resolve TrueLayer client_id / client_secret from keychain or env.
+//   2. Spawn an ephemeral local server (services/oauth) and open the browser.
+//   3. Exchange the captured authorization code for tokens.
+//   4. Call /data/v1/me to obtain provider metadata.
+//   5. Persist tokens to keychain and a row in `connections` (+ accounts via /accounts).
+
+import { randomUUID } from 'node:crypto';
 import { defineCommand } from 'citty';
-import { notImplemented } from '../lib/errors';
+import consola from 'consola';
+import { getDb } from '../db/client';
+import { accounts, connections } from '../db/schema';
+import { AuthError, ConfigError } from '../lib/errors';
+import { TRUELAYER_CLIENT_ID, TRUELAYER_CLIENT_SECRET, resolveSecret } from '../lib/secrets';
+import { accountNames, setToken } from '../services/keychain';
+import { runOAuthFlow } from '../services/oauth';
+import {
+  AUTH_BASE,
+  DEFAULT_PROVIDERS,
+  DEFAULT_SCOPE,
+  TrueLayerClient,
+} from '../services/truelayer';
+import type { TrueLayerAccount, TrueLayerMeResult } from '../types/truelayer';
+
+function buildAuthUrl(args: {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  providers: string;
+  scope: string;
+}): string {
+  const u = new URL('/', AUTH_BASE);
+  u.searchParams.set('response_type', 'code');
+  u.searchParams.set('client_id', args.clientId);
+  u.searchParams.set('redirect_uri', args.redirectUri);
+  u.searchParams.set('scope', args.scope);
+  u.searchParams.set('providers', args.providers);
+  u.searchParams.set('state', args.state);
+  return u.toString();
+}
+
+function maskAccountNumber(num: string | undefined): string | null {
+  if (!num) return null;
+  const digits = num.replace(/\D/g, '');
+  if (digits.length <= 4) return digits;
+  return digits.slice(-4);
+}
 
 export default defineCommand({
   meta: { name: 'link', description: 'Connect a bank via OAuth (TrueLayer)' },
   args: {
-    provider: { type: 'string', description: 'TrueLayer provider id (e.g. uk-ob-lloyds)' },
+    provider: {
+      type: 'string',
+      description: 'TrueLayer provider id (e.g. uk-ob-lloyds). Defaults to uk-oauth-all.',
+    },
+    scope: {
+      type: 'string',
+      description: 'Override OAuth scope (advanced).',
+    },
+    timeout: {
+      type: 'string',
+      description: 'OAuth flow timeout in seconds (default 300).',
+    },
   },
-  run() {
-    notImplemented('link', 2);
+  async run({ args }) {
+    const clientId = await resolveSecret(TRUELAYER_CLIENT_ID);
+    const clientSecret = await resolveSecret(TRUELAYER_CLIENT_SECRET);
+
+    const providers = (args.provider as string | undefined) ?? DEFAULT_PROVIDERS;
+    const scope = (args.scope as string | undefined) ?? DEFAULT_SCOPE;
+    const timeoutSecondsRaw = args.timeout as string | undefined;
+    const timeoutMs = timeoutSecondsRaw
+      ? Math.max(10, Number.parseInt(timeoutSecondsRaw, 10)) * 1000
+      : undefined;
+
+    consola.info(`Starting OAuth flow (providers=${providers})`);
+
+    const callback = await runOAuthFlow({
+      buildAuthUrl: (redirectUri, state) =>
+        buildAuthUrl({ clientId, redirectUri, state, providers, scope }),
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      onListening: ({ port, authUrl }) => {
+        consola.info(`Listening on http://localhost:${port}/callback`);
+        consola.info('Opening browser to TrueLayer auth...');
+        consola.log(`If your browser does not open automatically, visit:\n${authUrl}`);
+      },
+    });
+
+    consola.success('Authorization code captured. Exchanging for tokens...');
+
+    const tokens = await TrueLayerClient.exchangeAuthCode({
+      credentials: { clientId, clientSecret },
+      code: callback.code,
+      redirectUri: callback.redirectUri,
+    });
+
+    // Fetch provider metadata via /me. Use a single-shot client with the fresh
+    // tokens; persistence happens after we get the connection id.
+    const tempStore = createInertStore();
+    const initialBundle = {
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      expiresAtMs: Date.now() + tokens.expires_in * 1000,
+    };
+    const client = new TrueLayerClient({
+      credentials: { clientId, clientSecret },
+      store: tempStore,
+      initialTokens: initialBundle,
+    });
+    const me = await client.getMe();
+    const meResult: TrueLayerMeResult | undefined = me.results[0];
+    if (!meResult) {
+      throw new AuthError('TrueLayer /me returned no provider metadata.');
+    }
+
+    // Per PRD §8.1, the *connection* (PSD2 consent) lasts up to 90 days.
+    // If the API surfaces a consent_expires_at, prefer that; otherwise use 90d from now.
+    const connExpiresAt = meResult.consent_expires_at
+      ? new Date(meResult.consent_expires_at)
+      : new Date(Date.now() + 90 * 24 * 60 * 60 * 1000);
+
+    const connectionId = randomUUID();
+
+    // Persist tokens BEFORE writing the DB row so a partial failure leaves the
+    // keychain entries that the row would point at, not orphaned DB metadata.
+    await setToken(accountNames.access(connectionId), tokens.access_token);
+    await setToken(accountNames.refresh(connectionId), tokens.refresh_token);
+    await setToken(accountNames.expiry(connectionId), String(initialBundle.expiresAtMs));
+
+    const { db } = getDb();
+    const now = new Date();
+    db.insert(connections)
+      .values({
+        id: connectionId,
+        providerId: meResult.provider.provider_id,
+        providerName: meResult.provider.display_name,
+        createdAt: now,
+        expiresAt: connExpiresAt,
+        status: 'active',
+        lastSyncedAt: null,
+      })
+      .run();
+
+    // Best-effort: fetch accounts list so the user can immediately see what
+    // was linked. Failures here do not abort the link, since `ferret sync`
+    // will re-fetch accounts as part of normal operation.
+    let accountRows: TrueLayerAccount[] = [];
+    try {
+      const accountsResp = await client.getAccounts();
+      accountRows = accountsResp.results;
+    } catch (err) {
+      consola.warn(`Linked successfully but failed to list accounts: ${(err as Error).message}`);
+    }
+
+    if (accountRows.length > 0) {
+      for (const a of accountRows) {
+        try {
+          db.insert(accounts)
+            .values({
+              id: a.account_id,
+              connectionId,
+              accountType: a.account_type,
+              displayName: a.display_name,
+              iban: a.account_number?.iban ?? null,
+              sortCode: a.account_number?.sort_code ?? null,
+              accountNumber: maskAccountNumber(a.account_number?.number),
+              currency: a.currency,
+              balanceAvailable: null,
+              balanceCurrent: null,
+              balanceUpdatedAt: null,
+              isManual: false,
+            })
+            .run();
+        } catch (err) {
+          consola.warn(`Skipped account ${a.account_id.slice(0, 8)}…: ${(err as Error).message}`);
+        }
+      }
+    }
+
+    consola.success(
+      `Connected: ${meResult.provider.display_name} (expires ${connExpiresAt.toISOString().slice(0, 10)})`,
+    );
+    consola.info(`Connection id: ${connectionId}`);
+    if (accountRows.length > 0) {
+      consola.info(`Discovered ${accountRows.length} account(s).`);
+    }
   },
 });
+
+// A no-op store used during the initial /me call; we manage persistence
+// ourselves once the connection id is known.
+function createInertStore() {
+  return {
+    async load() {
+      throw new ConfigError('inert store: load() should not be called during initial linking');
+    },
+    async save() {
+      // ignore
+    },
+    async markNeedsReauth() {
+      // ignore
+    },
+  };
+}

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -12,7 +12,7 @@ import { defineCommand } from 'citty';
 import consola from 'consola';
 import { getDb } from '../db/client';
 import { accounts, connections } from '../db/schema';
-import { AuthError, ConfigError } from '../lib/errors';
+import { AuthError, DataIntegrityError, ValidationError } from '../lib/errors';
 import { TRUELAYER_CLIENT_ID, TRUELAYER_CLIENT_SECRET, resolveSecret } from '../lib/secrets';
 import { accountNames, setToken } from '../services/keychain';
 import { runOAuthFlow } from '../services/oauth';
@@ -41,11 +41,13 @@ function buildAuthUrl(args: {
   return u.toString();
 }
 
-function maskAccountNumber(num: string | undefined): string | null {
+// Per PRD §9.3, account numbers are masked only at the display layer.
+// We store the full digits-only value (file already chmod 0600 per §9.2)
+// and let the rendering layer truncate to last-4 when shown to humans.
+function normalizeAccountNumber(num: string | undefined): string | null {
   if (!num) return null;
   const digits = num.replace(/\D/g, '');
-  if (digits.length <= 4) return digits;
-  return digits.slice(-4);
+  return digits.length > 0 ? digits : null;
 }
 
 export default defineCommand({
@@ -71,9 +73,14 @@ export default defineCommand({
     const providers = (args.provider as string | undefined) ?? DEFAULT_PROVIDERS;
     const scope = (args.scope as string | undefined) ?? DEFAULT_SCOPE;
     const timeoutSecondsRaw = args.timeout as string | undefined;
-    const timeoutMs = timeoutSecondsRaw
-      ? Math.max(10, Number.parseInt(timeoutSecondsRaw, 10)) * 1000
-      : undefined;
+    let timeoutMs: number | undefined;
+    if (timeoutSecondsRaw !== undefined) {
+      const parsed = Number.parseInt(timeoutSecondsRaw, 10);
+      if (Number.isNaN(parsed) || parsed <= 0) {
+        throw new ValidationError('--timeout must be a positive integer (seconds)');
+      }
+      timeoutMs = Math.max(10, parsed) * 1000;
+    }
 
     consola.info(`Starting OAuth flow (providers=${providers})`);
 
@@ -131,17 +138,26 @@ export default defineCommand({
 
     const { db } = getDb();
     const now = new Date();
-    db.insert(connections)
-      .values({
-        id: connectionId,
-        providerId: meResult.provider.provider_id,
-        providerName: meResult.provider.display_name,
-        createdAt: now,
-        expiresAt: connExpiresAt,
-        status: 'active',
-        lastSyncedAt: null,
-      })
-      .run();
+    // Bun's drizzle SQLite driver runs `.run()` synchronously and surfaces
+    // failures via thrown exceptions; wrap so a constraint or IO error becomes
+    // a typed DataIntegrityError instead of an unhandled rejection.
+    try {
+      db.insert(connections)
+        .values({
+          id: connectionId,
+          providerId: meResult.provider.provider_id,
+          providerName: meResult.provider.display_name,
+          createdAt: now,
+          expiresAt: connExpiresAt,
+          status: 'active',
+          lastSyncedAt: null,
+        })
+        .run();
+    } catch (err) {
+      throw new DataIntegrityError(
+        `Failed to persist connection row for ${meResult.provider.display_name}: ${(err as Error).message}`,
+      );
+    }
 
     // Best-effort: fetch accounts list so the user can immediately see what
     // was linked. Failures here do not abort the link, since `ferret sync`
@@ -165,7 +181,7 @@ export default defineCommand({
               displayName: a.display_name,
               iban: a.account_number?.iban ?? null,
               sortCode: a.account_number?.sort_code ?? null,
-              accountNumber: maskAccountNumber(a.account_number?.number),
+              accountNumber: normalizeAccountNumber(a.account_number?.number),
               currency: a.currency,
               balanceAvailable: null,
               balanceCurrent: null,
@@ -190,11 +206,16 @@ export default defineCommand({
 });
 
 // A no-op store used during the initial /me call; we manage persistence
-// ourselves once the connection id is known.
+// ourselves once the connection id is known. `initialTokens` is always passed
+// to the client, so `load()` should never fire — if it does, that's a logic
+// bug on the caller's side, not a config problem.
 function createInertStore() {
   return {
-    async load() {
-      throw new ConfigError('inert store: load() should not be called during initial linking');
+    async load(): Promise<never> {
+      throw new Error(
+        'createInertStore: load() invoked, but the inert store has no persisted tokens. ' +
+          'Pass initialTokens to TrueLayerClient before any request that may trigger a refresh.',
+      );
     },
     async save() {
       // ignore

--- a/src/commands/unlink.ts
+++ b/src/commands/unlink.ts
@@ -35,9 +35,6 @@ export default defineCommand({
 
     const { db } = getDb();
     const existing = db.select().from(connections).where(eq(connections.id, connectionId)).all();
-    if (existing.length === 0) {
-      throw new ValidationError(`No connection with id "${connectionId}".`);
-    }
     const conn = existing[0];
     if (!conn) {
       throw new ValidationError(`No connection with id "${connectionId}".`);

--- a/src/commands/unlink.ts
+++ b/src/commands/unlink.ts
@@ -1,12 +1,57 @@
+// `ferret unlink` — revoke a connection.
+//
+// Per the issue + PRD §4.1: this should remove tokens and stop the connection
+// from being used. We deliberately do NOT delete `accounts` or `transactions`
+// rows: the user's transaction history is the most valuable artefact of using
+// the tool, and we want it to remain queryable for `ferret ls` / `ferret ask`
+// even after a bank is unlinked.
+//
+// Behaviour:
+//   - Delete every keychain entry under `truelayer:{connection_id}:*`
+//   - Mark the connection row `status='revoked'`
+//   - Leave `accounts` and `transactions` rows intact (audit trail).
+//
+// If the user truly wants to remove the data, they can drop rows from SQLite
+// directly (or wait for a future `ferret purge` command).
+
 import { defineCommand } from 'citty';
-import { notImplemented } from '../lib/errors';
+import consola from 'consola';
+import { eq } from 'drizzle-orm';
+import { getDb } from '../db/client';
+import { connections } from '../db/schema';
+import { ValidationError } from '../lib/errors';
+import { deleteAllForConnection } from '../services/keychain';
 
 export default defineCommand({
   meta: { name: 'unlink', description: 'Remove a connection and revoke tokens' },
   args: {
     connectionId: { type: 'positional', description: 'Connection id', required: true },
   },
-  run() {
-    notImplemented('unlink', 2);
+  async run({ args }) {
+    const connectionId = String(args.connectionId);
+    if (!connectionId) {
+      throw new ValidationError('connection id is required');
+    }
+
+    const { db } = getDb();
+    const existing = db.select().from(connections).where(eq(connections.id, connectionId)).all();
+    if (existing.length === 0) {
+      throw new ValidationError(`No connection with id "${connectionId}".`);
+    }
+    const conn = existing[0];
+    if (!conn) {
+      throw new ValidationError(`No connection with id "${connectionId}".`);
+    }
+
+    const removed = await deleteAllForConnection(connectionId).catch((err) => {
+      consola.warn(`Could not fully clear keychain entries: ${(err as Error).message}`);
+      return 0;
+    });
+
+    db.update(connections).set({ status: 'revoked' }).where(eq(connections.id, connectionId)).run();
+
+    consola.success(
+      `Unlinked ${conn.providerName} (${connectionId}). Removed ${removed} keychain entr${removed === 1 ? 'y' : 'ies'}; transaction history retained.`,
+    );
   },
 });

--- a/src/lib/secrets.ts
+++ b/src/lib/secrets.ts
@@ -1,0 +1,61 @@
+// Resolves secrets from the OS keychain first, falling back to environment variables.
+// Used for values that may live in either place per PRD §9.1:
+//   - TrueLayer client_secret
+//   - Anthropic API key
+//
+// Throws ConfigError when neither source has a value.
+
+import { getToken } from '../services/keychain';
+import { ConfigError } from './errors';
+
+export interface SecretLookup {
+  /** Keychain account name under service `ferret`. */
+  keychainAccount: string;
+  /** Environment variable to fall back to. */
+  envVar: string;
+  /** Human label used in error messages. */
+  label: string;
+}
+
+export const TRUELAYER_CLIENT_ID: SecretLookup = {
+  keychainAccount: 'truelayer:client_id',
+  envVar: 'TRUELAYER_CLIENT_ID',
+  label: 'TrueLayer client id',
+};
+
+export const TRUELAYER_CLIENT_SECRET: SecretLookup = {
+  keychainAccount: 'truelayer:client_secret',
+  envVar: 'TRUELAYER_CLIENT_SECRET',
+  label: 'TrueLayer client secret',
+};
+
+export const ANTHROPIC_API_KEY: SecretLookup = {
+  keychainAccount: 'anthropic:api_key',
+  envVar: 'ANTHROPIC_API_KEY',
+  label: 'Anthropic API key',
+};
+
+/**
+ * Resolves a secret. Tries the keychain first; on miss, falls back to the env var.
+ * Throws ConfigError if neither source has the value.
+ */
+export async function resolveSecret(spec: SecretLookup): Promise<string> {
+  const fromKeychain = await getToken(spec.keychainAccount).catch(() => null);
+  if (fromKeychain && fromKeychain.length > 0) return fromKeychain;
+
+  const fromEnv = process.env[spec.envVar];
+  if (fromEnv && fromEnv.length > 0) return fromEnv;
+
+  throw new ConfigError(
+    `Missing ${spec.label}. Set the ${spec.envVar} env var or store under keychain account "${spec.keychainAccount}".`,
+  );
+}
+
+/** Optional variant: returns null if neither source has the value (no throw). */
+export async function tryResolveSecret(spec: SecretLookup): Promise<string | null> {
+  const fromKeychain = await getToken(spec.keychainAccount).catch(() => null);
+  if (fromKeychain && fromKeychain.length > 0) return fromKeychain;
+  const fromEnv = process.env[spec.envVar];
+  if (fromEnv && fromEnv.length > 0) return fromEnv;
+  return null;
+}

--- a/src/lib/secrets.ts
+++ b/src/lib/secrets.ts
@@ -36,11 +36,30 @@ export const ANTHROPIC_API_KEY: SecretLookup = {
 };
 
 /**
+ * Reads from the keychain, distinguishing a "miss" (returns null) from an
+ * actual backend error (perm denied, daemon unavailable, native binding
+ * missing). Misses fall through to the env-var path; real errors are
+ * re-thrown as ConfigError so the user sees the underlying cause.
+ */
+async function readFromKeychain(spec: SecretLookup): Promise<string | null> {
+  try {
+    return await getToken(spec.keychainAccount);
+  } catch (err) {
+    // ConfigError already carries enough context; rethrow as-is.
+    if (err instanceof ConfigError) throw err;
+    throw new ConfigError(
+      `Failed to read ${spec.label} from keychain account "${spec.keychainAccount}": ${(err as Error).message}`,
+    );
+  }
+}
+
+/**
  * Resolves a secret. Tries the keychain first; on miss, falls back to the env var.
- * Throws ConfigError if neither source has the value.
+ * Throws ConfigError if neither source has the value, or if the keychain read
+ * itself failed (rather than silently masking the failure as a miss).
  */
 export async function resolveSecret(spec: SecretLookup): Promise<string> {
-  const fromKeychain = await getToken(spec.keychainAccount).catch(() => null);
+  const fromKeychain = await readFromKeychain(spec);
   if (fromKeychain && fromKeychain.length > 0) return fromKeychain;
 
   const fromEnv = process.env[spec.envVar];
@@ -53,7 +72,7 @@ export async function resolveSecret(spec: SecretLookup): Promise<string> {
 
 /** Optional variant: returns null if neither source has the value (no throw). */
 export async function tryResolveSecret(spec: SecretLookup): Promise<string | null> {
-  const fromKeychain = await getToken(spec.keychainAccount).catch(() => null);
+  const fromKeychain = await readFromKeychain(spec);
   if (fromKeychain && fromKeychain.length > 0) return fromKeychain;
   const fromEnv = process.env[spec.envVar];
   if (fromEnv && fromEnv.length > 0) return fromEnv;

--- a/src/services/keychain.ts
+++ b/src/services/keychain.ts
@@ -29,14 +29,17 @@ async function getBackend(): Promise<KeychainBackend> {
   if (loadAttempted) {
     throw new ConfigError('Keychain backend unavailable.');
   }
-  loadAttempted = true;
   try {
     // Dynamic import keeps this module test-friendly: if keytar fails to load
     // (no native binding for current platform), we surface a typed error.
+    // Only flip `loadAttempted` AFTER a successful import so a transient
+    // failure (e.g. ENOENT for native binding mid-install) can be retried by
+    // a subsequent call instead of being permanently latched.
     const mod = (await import('keytar')) as unknown as KeychainBackend & {
       default?: KeychainBackend;
     };
     backend = mod.default ?? mod;
+    loadAttempted = true;
     return backend;
   } catch (err) {
     throw new ConfigError(

--- a/src/services/keychain.ts
+++ b/src/services/keychain.ts
@@ -1,0 +1,91 @@
+// Thin wrapper around `keytar` per PRD §9.1.
+//
+// All secrets live under service "ferret". Account names follow the convention:
+//   - truelayer:{connection_id}:access
+//   - truelayer:{connection_id}:refresh
+//   - truelayer:client_secret
+//   - truelayer:client_id (optional)
+//   - anthropic:api_key
+//
+// The underlying keytar module is loaded dynamically so tests can swap it out
+// via `setKeychainBackend`. We never log token values.
+
+import { ConfigError } from '../lib/errors';
+
+export const SERVICE = 'ferret';
+
+export interface KeychainBackend {
+  setPassword(service: string, account: string, password: string): Promise<void>;
+  getPassword(service: string, account: string): Promise<string | null>;
+  deletePassword(service: string, account: string): Promise<boolean>;
+  findCredentials(service: string): Promise<Array<{ account: string; password: string }>>;
+}
+
+let backend: KeychainBackend | null = null;
+let loadAttempted = false;
+
+async function getBackend(): Promise<KeychainBackend> {
+  if (backend) return backend;
+  if (loadAttempted) {
+    throw new ConfigError('Keychain backend unavailable.');
+  }
+  loadAttempted = true;
+  try {
+    // Dynamic import keeps this module test-friendly: if keytar fails to load
+    // (no native binding for current platform), we surface a typed error.
+    const mod = (await import('keytar')) as unknown as KeychainBackend & {
+      default?: KeychainBackend;
+    };
+    backend = mod.default ?? mod;
+    return backend;
+  } catch (err) {
+    throw new ConfigError(
+      `Failed to load OS keychain (keytar): ${(err as Error).message}. On linux, ensure libsecret-1-dev is installed.`,
+    );
+  }
+}
+
+/** Test/CI only: inject a stub backend. */
+export function setKeychainBackend(stub: KeychainBackend | null): void {
+  backend = stub;
+  loadAttempted = stub !== null;
+}
+
+export async function setToken(account: string, value: string): Promise<void> {
+  const b = await getBackend();
+  await b.setPassword(SERVICE, account, value);
+}
+
+export async function getToken(account: string): Promise<string | null> {
+  const b = await getBackend();
+  return b.getPassword(SERVICE, account);
+}
+
+export async function deleteToken(account: string): Promise<boolean> {
+  const b = await getBackend();
+  return b.deletePassword(SERVICE, account);
+}
+
+/** Removes every keychain entry for a given connection id. Returns the count deleted. */
+export async function deleteAllForConnection(connectionId: string): Promise<number> {
+  const b = await getBackend();
+  const all = await b.findCredentials(SERVICE);
+  const prefix = `truelayer:${connectionId}:`;
+  let deleted = 0;
+  for (const cred of all) {
+    if (cred.account.startsWith(prefix)) {
+      const ok = await b.deletePassword(SERVICE, cred.account);
+      if (ok) deleted += 1;
+    }
+  }
+  return deleted;
+}
+
+// Helpers to construct canonical account names.
+export const accountNames = {
+  access: (connectionId: string): string => `truelayer:${connectionId}:access`,
+  refresh: (connectionId: string): string => `truelayer:${connectionId}:refresh`,
+  expiry: (connectionId: string): string => `truelayer:${connectionId}:expires_at`,
+  trueLayerClientSecret: 'truelayer:client_secret',
+  anthropicApiKey: 'anthropic:api_key',
+} as const;

--- a/src/services/oauth.ts
+++ b/src/services/oauth.ts
@@ -151,70 +151,64 @@ export async function runOAuthFlow(
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const opener = opts.openBrowser ?? defaultOpenBrowser;
 
+  // Build dedup wrappers up front so we can hand them to the server bind.
+  let settled = false;
+  let resolveResult!: (r: OAuthCallbackResult) => void;
+  let rejectResult!: (e: Error) => void;
+  const result = new Promise<OAuthCallbackResult>((resolve, reject) => {
+    resolveResult = (r) => {
+      if (settled) return;
+      settled = true;
+      resolve(r);
+    };
+    rejectResult = (e) => {
+      if (settled) return;
+      settled = true;
+      reject(e);
+    };
+  });
+
+  // Bind the real callback server directly, retrying with a fresh port on
+  // collision. We deliberately avoid a probe-then-bind two-step (which has a
+  // TOCTOU race: another process can grab the port between probe.stop() and
+  // the real bind).
   let server: ServerHandle | null = null;
-  let port = 0;
-  let bound = false;
   let lastErr: unknown = null;
   for (let attempt = 0; attempt < MAX_PORT_RETRIES; attempt++) {
     const candidate = pickPort();
     try {
-      // Probe for binding success: a port collision throws synchronously here.
-      const probe = Bun.serve({
-        port: candidate,
-        hostname: '127.0.0.1',
-        fetch: () => new Response('ok'),
-      });
-      probe.stop(true);
-      port = candidate;
-      bound = true;
+      server = startCallbackServer(candidate, state, resolveResult, rejectResult);
       break;
     } catch (err) {
+      // Bun surfaces port collisions as a synchronous throw; retry with a new
+      // random port. Other errors (e.g. permission denied) will eventually
+      // surface via lastErr if all attempts exhaust.
       lastErr = err;
     }
   }
-  if (!bound) {
+  if (!server) {
     throw new NetworkError(
       `Could not bind a localhost port in ${PORT_MIN}-${PORT_MAX} after ${MAX_PORT_RETRIES} attempts: ${(lastErr as Error)?.message ?? 'unknown'}`,
     );
   }
-
+  const port = server.port;
   const redirectUri = `http://localhost:${port}/callback`;
   const authUrl = opts.buildAuthUrl(redirectUri, state);
 
-  const result = await new Promise<OAuthCallbackResult>((resolve, reject) => {
-    let settled = false;
-    const wrap =
-      <T>(fn: (v: T) => void) =>
-      (v: T) => {
-        if (settled) return;
-        settled = true;
-        fn(v);
-      };
-    const wResolve = wrap(resolve);
-    const wReject = wrap(reject);
-
-    try {
-      server = startCallbackServer(port, state, wResolve, wReject);
-    } catch (err) {
-      wReject(
-        new NetworkError(`Failed to start callback server on :${port} — ${(err as Error).message}`),
-      );
-      return;
-    }
-
+  try {
     opts.onListening?.({ port, redirectUri, authUrl });
     opener(authUrl);
 
     const timer = setTimeout(() => {
-      wReject(new AuthError(`OAuth flow timed out after ${Math.round(timeoutMs / 1000)}s.`));
+      rejectResult(new AuthError(`OAuth flow timed out after ${Math.round(timeoutMs / 1000)}s.`));
     }, timeoutMs);
-    // Don't keep the event loop alive past resolution.
     if (typeof timer === 'object' && timer && 'unref' in timer) {
       (timer as { unref: () => void }).unref();
     }
-  }).finally(() => {
-    server?.stop(true);
-  });
 
-  return { ...result, redirectUri, port };
+    const captured = await result;
+    return { ...captured, redirectUri, port };
+  } finally {
+    server.stop(true);
+  }
 }

--- a/src/services/oauth.ts
+++ b/src/services/oauth.ts
@@ -1,0 +1,220 @@
+// Ephemeral local OAuth callback server for `ferret link`.
+//
+// Per PRD §4.1 and §8.1:
+//   - Random port in 8000-9999, retry up to 3 times on collision
+//   - 5-minute auto-shutdown
+//   - CSRF state validation
+//   - Opens default browser via macOS `open` / linux `xdg-open`
+//
+// We expose `runOAuthFlow()` which returns the captured code+state,
+// plus `generateState()` and `validateState()` as pure helpers (testable).
+
+import { randomBytes } from 'node:crypto';
+import { platform } from 'node:os';
+import { AuthError, NetworkError } from '../lib/errors';
+
+export const PORT_MIN = 8000;
+export const PORT_MAX = 9999;
+export const MAX_PORT_RETRIES = 3;
+export const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** Cryptographically-random CSRF state token (hex). */
+export function generateState(bytes = 32): string {
+  return randomBytes(bytes).toString('hex');
+}
+
+/** Constant-time-ish equality check for state validation. */
+export function validateState(expected: string, actual: string | null | undefined): boolean {
+  if (!actual || expected.length !== actual.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < expected.length; i++) {
+    mismatch |= expected.charCodeAt(i) ^ actual.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+function pickPort(): number {
+  return PORT_MIN + Math.floor(Math.random() * (PORT_MAX - PORT_MIN + 1));
+}
+
+export interface OAuthCallbackResult {
+  code: string;
+  state: string;
+}
+
+export interface OAuthFlowOptions {
+  /** Builds the auth URL given the chosen redirect URI. */
+  buildAuthUrl: (redirectUri: string, state: string) => string;
+  /** Override timeout (ms). */
+  timeoutMs?: number;
+  /** Override expected state (defaults to a freshly generated one). */
+  state?: string;
+  /** Inject browser opener (mainly for tests). Defaults to platform `open`. */
+  openBrowser?: (url: string) => void;
+  /** Callback invoked once the server is listening. */
+  onListening?: (info: { port: number; redirectUri: string; authUrl: string }) => void;
+}
+
+const SUCCESS_HTML = `<!doctype html><html><head><meta charset="utf-8"><title>ferret: connected</title>
+<style>body{font-family:-apple-system,BlinkMacSystemFont,sans-serif;background:#0a0a0a;color:#eaeaea;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;}
+.card{padding:32px 48px;border:1px solid #2a2a2a;border-radius:8px;text-align:center;}
+h1{margin:0 0 8px;font-size:18px;font-weight:500;}p{margin:0;color:#888;font-size:14px;}</style></head>
+<body><div class="card"><h1>ferret connected</h1><p>You can close this tab and return to your terminal.</p></div></body></html>`;
+
+const ERROR_HTML = (msg: string): string =>
+  `<!doctype html><html><head><meta charset="utf-8"><title>ferret: error</title></head>
+<body style="font-family:sans-serif;padding:40px;background:#0a0a0a;color:#eaeaea;">
+<h1 style="font-size:18px;">ferret: ${escapeHtml(msg)}</h1>
+<p style="color:#888;">Return to the terminal for details.</p></body></html>`;
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>'"`]/g, (c) => `&#${c.charCodeAt(0)};`);
+}
+
+export function defaultOpenBrowser(url: string): void {
+  const cmd =
+    platform() === 'darwin'
+      ? ['open', url]
+      : platform() === 'win32'
+        ? ['cmd', '/c', 'start', '""', url]
+        : ['xdg-open', url];
+  try {
+    Bun.spawn(cmd, { stdout: 'ignore', stderr: 'ignore' });
+  } catch {
+    // Browser open is best-effort; the URL is also printed to stdout by the caller.
+  }
+}
+
+interface ServerHandle {
+  port: number;
+  stop: (closeActive?: boolean) => void;
+}
+
+function startCallbackServer(
+  port: number,
+  expectedState: string,
+  resolve: (r: OAuthCallbackResult) => void,
+  reject: (e: Error) => void,
+): ServerHandle {
+  // Bun.serve binds eagerly; if the port is busy, an exception is thrown synchronously.
+  const server = Bun.serve({
+    port,
+    hostname: '127.0.0.1',
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname !== '/callback') {
+        return new Response('Not found', { status: 404 });
+      }
+      const error = url.searchParams.get('error');
+      const errorDescription = url.searchParams.get('error_description');
+      if (error) {
+        const msg = errorDescription ? `${error}: ${errorDescription}` : error;
+        reject(new AuthError(`TrueLayer authorization failed — ${msg}`));
+        return new Response(ERROR_HTML(msg), {
+          status: 400,
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        });
+      }
+      const code = url.searchParams.get('code');
+      const state = url.searchParams.get('state');
+      if (!code) {
+        reject(new AuthError('TrueLayer callback missing `code` parameter.'));
+        return new Response(ERROR_HTML('missing code'), {
+          status: 400,
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        });
+      }
+      if (!validateState(expectedState, state)) {
+        reject(new AuthError('OAuth state mismatch — possible CSRF. Aborting.'));
+        return new Response(ERROR_HTML('state mismatch'), {
+          status: 400,
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        });
+      }
+      resolve({ code, state: state as string });
+      return new Response(SUCCESS_HTML, {
+        status: 200,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      });
+    },
+  });
+  return {
+    port: server.port ?? port,
+    stop: (closeActive = true) => server.stop(closeActive),
+  };
+}
+
+export async function runOAuthFlow(
+  opts: OAuthFlowOptions,
+): Promise<OAuthCallbackResult & { redirectUri: string; port: number }> {
+  const state = opts.state ?? generateState();
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const opener = opts.openBrowser ?? defaultOpenBrowser;
+
+  let server: ServerHandle | null = null;
+  let port = 0;
+  let bound = false;
+  let lastErr: unknown = null;
+  for (let attempt = 0; attempt < MAX_PORT_RETRIES; attempt++) {
+    const candidate = pickPort();
+    try {
+      // Probe for binding success: a port collision throws synchronously here.
+      const probe = Bun.serve({
+        port: candidate,
+        hostname: '127.0.0.1',
+        fetch: () => new Response('ok'),
+      });
+      probe.stop(true);
+      port = candidate;
+      bound = true;
+      break;
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  if (!bound) {
+    throw new NetworkError(
+      `Could not bind a localhost port in ${PORT_MIN}-${PORT_MAX} after ${MAX_PORT_RETRIES} attempts: ${(lastErr as Error)?.message ?? 'unknown'}`,
+    );
+  }
+
+  const redirectUri = `http://localhost:${port}/callback`;
+  const authUrl = opts.buildAuthUrl(redirectUri, state);
+
+  const result = await new Promise<OAuthCallbackResult>((resolve, reject) => {
+    let settled = false;
+    const wrap =
+      <T>(fn: (v: T) => void) =>
+      (v: T) => {
+        if (settled) return;
+        settled = true;
+        fn(v);
+      };
+    const wResolve = wrap(resolve);
+    const wReject = wrap(reject);
+
+    try {
+      server = startCallbackServer(port, state, wResolve, wReject);
+    } catch (err) {
+      wReject(
+        new NetworkError(`Failed to start callback server on :${port} — ${(err as Error).message}`),
+      );
+      return;
+    }
+
+    opts.onListening?.({ port, redirectUri, authUrl });
+    opener(authUrl);
+
+    const timer = setTimeout(() => {
+      wReject(new AuthError(`OAuth flow timed out after ${Math.round(timeoutMs / 1000)}s.`));
+    }, timeoutMs);
+    // Don't keep the event loop alive past resolution.
+    if (typeof timer === 'object' && timer && 'unref' in timer) {
+      (timer as { unref: () => void }).unref();
+    }
+  }).finally(() => {
+    server?.stop(true);
+  });
+
+  return { ...result, redirectUri, port };
+}

--- a/src/services/truelayer.ts
+++ b/src/services/truelayer.ts
@@ -1,0 +1,423 @@
+// TrueLayer Data API client per PRD §8.1.
+//
+// Behaviour:
+//   - 401 -> refresh once and retry; if still 401, surface AuthError and
+//     mark the connection as needing re-auth.
+//   - 403 -> AuthError flagged as needing re-consent (no retry).
+//   - 429 -> respect Retry-After (seconds), exponential backoff with jitter
+//     (250ms base) up to 3 retries.
+//   - 5xx -> exponential backoff with jitter (250ms base) up to 3 retries.
+//   - 4xx (other) -> NetworkError with status + body context.
+//
+// Tokens are owned by the caller (commands/services). A `TokenStore` callback
+// is passed in; the client invokes it after a successful refresh so callers
+// can persist the new tokens (keychain + DB).
+
+import { AuthError, NetworkError, RateLimitError } from '../lib/errors';
+import type {
+  TrueLayerAccountsResponse,
+  TrueLayerBalanceResponse,
+  TrueLayerCardBalanceResponse,
+  TrueLayerCardsResponse,
+  TrueLayerDateRange,
+  TrueLayerErrorBody,
+  TrueLayerMeResponse,
+  TrueLayerTokenResponse,
+  TrueLayerTransactionsResponse,
+} from '../types/truelayer';
+
+export const AUTH_BASE = 'https://auth.truelayer.com';
+export const DATA_BASE = 'https://api.truelayer.com/data/v1';
+
+export const DEFAULT_SCOPE = 'info accounts balance transactions offline_access';
+export const DEFAULT_PROVIDERS = 'uk-oauth-all';
+
+export interface TrueLayerCredentials {
+  clientId: string;
+  clientSecret: string;
+}
+
+export interface TokenBundle {
+  accessToken: string;
+  refreshToken: string;
+  /** Wall-clock ms when the access token expires. */
+  expiresAtMs: number;
+}
+
+export interface TokenStore {
+  /** Returns the latest cached tokens (caller may have refreshed elsewhere). */
+  load(): Promise<TokenBundle>;
+  /** Persists newly refreshed tokens (keychain + DB updates). */
+  save(bundle: TokenBundle): Promise<void>;
+  /** Marks the connection as needing re-consent (called on 403 / second 401). */
+  markNeedsReauth(): Promise<void>;
+}
+
+/** Minimal fetch type used for testability. */
+export type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+export interface TrueLayerClientOptions {
+  credentials: TrueLayerCredentials;
+  store: TokenStore;
+  fetch?: FetchLike;
+  /** Pre-load token bundle to avoid a round trip on first request. */
+  initialTokens?: TokenBundle;
+  /** ms-resolution clock; injectable for tests. */
+  now?: () => number;
+  /** ms-resolution sleep; injectable for tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Override max retries for 429 / 5xx (default 3). */
+  maxRetries?: number;
+  /** Random function (injectable for jitter determinism in tests). */
+  random?: () => number;
+}
+
+const DEFAULT_RETRIES = 3;
+const BACKOFF_BASE_MS = 250;
+const TOKEN_REFRESH_SKEW_MS = 60_000; // refresh 60s before expiry per PRD §8.1
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+export class TrueLayerClient {
+  private readonly credentials: TrueLayerCredentials;
+  private readonly store: TokenStore;
+  private readonly fetchImpl: FetchLike;
+  private readonly nowFn: () => number;
+  private readonly sleepFn: (ms: number) => Promise<void>;
+  private readonly randomFn: () => number;
+  private readonly maxRetries: number;
+  private tokens: TokenBundle | null;
+  /** In-flight refresh promise, deduped across concurrent callers. */
+  private refreshing: Promise<TokenBundle> | null = null;
+
+  constructor(opts: TrueLayerClientOptions) {
+    this.credentials = opts.credentials;
+    this.store = opts.store;
+    this.fetchImpl = opts.fetch ?? ((input, init) => fetch(input, init));
+    this.nowFn = opts.now ?? (() => Date.now());
+    this.sleepFn = opts.sleep ?? defaultSleep;
+    this.randomFn = opts.random ?? Math.random;
+    this.maxRetries = opts.maxRetries ?? DEFAULT_RETRIES;
+    this.tokens = opts.initialTokens ?? null;
+  }
+
+  // ---------- Token management ----------
+
+  /**
+   * One-shot exchange of an authorization code for tokens. Used by `ferret link`.
+   * No token store / retry logic is needed here.
+   */
+  static async exchangeAuthCode(args: {
+    credentials: TrueLayerCredentials;
+    code: string;
+    redirectUri: string;
+    fetch?: FetchLike;
+  }): Promise<TrueLayerTokenResponse> {
+    const fetchImpl =
+      args.fetch ?? ((input: string | URL, init?: RequestInit) => fetch(input, init));
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: args.credentials.clientId,
+      client_secret: args.credentials.clientSecret,
+      redirect_uri: args.redirectUri,
+      code: args.code,
+    });
+    const res = await fetchImpl(`${AUTH_BASE}/connect/token`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+    if (!res.ok) {
+      const text = await safeReadText(res);
+      throw new AuthError(
+        `TrueLayer token exchange failed (${res.status}): ${truncate(text, 500)}`,
+      );
+    }
+    return (await res.json()) as TrueLayerTokenResponse;
+  }
+
+  /** Standalone refresh helper (used internally and by callers that hold a refresh token directly). */
+  static async refreshAccessToken(args: {
+    credentials: TrueLayerCredentials;
+    refreshToken: string;
+    fetch?: FetchLike;
+  }): Promise<TrueLayerTokenResponse> {
+    const fetchImpl =
+      args.fetch ?? ((input: string | URL, init?: RequestInit) => fetch(input, init));
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: args.credentials.clientId,
+      client_secret: args.credentials.clientSecret,
+      refresh_token: args.refreshToken,
+    });
+    const res = await fetchImpl(`${AUTH_BASE}/connect/token`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+    if (!res.ok) {
+      const text = await safeReadText(res);
+      throw new AuthError(`TrueLayer token refresh failed (${res.status}): ${truncate(text, 500)}`);
+    }
+    return (await res.json()) as TrueLayerTokenResponse;
+  }
+
+  // Instance wrappers that match the PRD §8.1 surface for Phase 2 consumers.
+  async exchangeAuthCode(code: string, redirectUri: string): Promise<TrueLayerTokenResponse> {
+    return TrueLayerClient.exchangeAuthCode({ credentials: this.credentials, code, redirectUri });
+  }
+
+  async refreshAccessToken(refreshToken: string): Promise<TrueLayerTokenResponse> {
+    return TrueLayerClient.refreshAccessToken({ credentials: this.credentials, refreshToken });
+  }
+
+  // ---------- Data endpoints ----------
+
+  async getMe(accessToken?: string): Promise<TrueLayerMeResponse> {
+    return this.requestJson<TrueLayerMeResponse>('GET', '/me', {
+      accessTokenOverride: accessToken,
+    });
+  }
+
+  async getAccounts(accessToken?: string): Promise<TrueLayerAccountsResponse> {
+    return this.requestJson<TrueLayerAccountsResponse>('GET', '/accounts', {
+      accessTokenOverride: accessToken,
+    });
+  }
+
+  async getAccountBalance(
+    accountId: string,
+    accessToken?: string,
+  ): Promise<TrueLayerBalanceResponse> {
+    return this.requestJson<TrueLayerBalanceResponse>(
+      'GET',
+      `/accounts/${encodeURIComponent(accountId)}/balance`,
+      { accessTokenOverride: accessToken },
+    );
+  }
+
+  async getAccountTransactions(
+    accountId: string,
+    range: TrueLayerDateRange = {},
+    accessToken?: string,
+  ): Promise<TrueLayerTransactionsResponse> {
+    const path = withDateRange(`/accounts/${encodeURIComponent(accountId)}/transactions`, range);
+    return this.requestJson<TrueLayerTransactionsResponse>('GET', path, {
+      accessTokenOverride: accessToken,
+    });
+  }
+
+  async getPendingTransactions(
+    accountId: string,
+    accessToken?: string,
+  ): Promise<TrueLayerTransactionsResponse> {
+    return this.requestJson<TrueLayerTransactionsResponse>(
+      'GET',
+      `/accounts/${encodeURIComponent(accountId)}/transactions/pending`,
+      { accessTokenOverride: accessToken },
+    );
+  }
+
+  async getCards(accessToken?: string): Promise<TrueLayerCardsResponse> {
+    return this.requestJson<TrueLayerCardsResponse>('GET', '/cards', {
+      accessTokenOverride: accessToken,
+    });
+  }
+
+  async getCardBalance(
+    cardId: string,
+    accessToken?: string,
+  ): Promise<TrueLayerCardBalanceResponse> {
+    return this.requestJson<TrueLayerCardBalanceResponse>(
+      'GET',
+      `/cards/${encodeURIComponent(cardId)}/balance`,
+      { accessTokenOverride: accessToken },
+    );
+  }
+
+  async getCardTransactions(
+    cardId: string,
+    range: TrueLayerDateRange = {},
+    accessToken?: string,
+  ): Promise<TrueLayerTransactionsResponse> {
+    const path = withDateRange(`/cards/${encodeURIComponent(cardId)}/transactions`, range);
+    return this.requestJson<TrueLayerTransactionsResponse>('GET', path, {
+      accessTokenOverride: accessToken,
+    });
+  }
+
+  // ---------- Internals ----------
+
+  private async getValidAccessToken(): Promise<string> {
+    if (!this.tokens) {
+      this.tokens = await this.store.load();
+    }
+    if (this.tokens.expiresAtMs - this.nowFn() <= TOKEN_REFRESH_SKEW_MS) {
+      const refreshed = await this.refreshTokens();
+      return refreshed.accessToken;
+    }
+    return this.tokens.accessToken;
+  }
+
+  private async refreshTokens(): Promise<TokenBundle> {
+    if (this.refreshing) return this.refreshing;
+    const refreshToken = this.tokens?.refreshToken;
+    if (!refreshToken) {
+      throw new AuthError('No refresh token available; re-link the connection.');
+    }
+    this.refreshing = (async () => {
+      try {
+        const resp = await TrueLayerClient.refreshAccessToken({
+          credentials: this.credentials,
+          refreshToken,
+          fetch: this.fetchImpl,
+        });
+        const bundle: TokenBundle = {
+          accessToken: resp.access_token,
+          refreshToken: resp.refresh_token ?? refreshToken,
+          expiresAtMs: this.nowFn() + resp.expires_in * 1000,
+        };
+        this.tokens = bundle;
+        await this.store.save(bundle);
+        return bundle;
+      } finally {
+        this.refreshing = null;
+      }
+    })();
+    return this.refreshing;
+  }
+
+  private async requestJson<T>(
+    method: string,
+    path: string,
+    opts: { accessTokenOverride?: string } = {},
+  ): Promise<T> {
+    const url = `${DATA_BASE}${path}`;
+    let attempt = 0;
+    let refreshedOnce = false;
+    let accessToken = opts.accessTokenOverride ?? (await this.getValidAccessToken());
+
+    while (true) {
+      const res = await this.fetchImpl(url, {
+        method,
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          accept: 'application/json',
+        },
+      });
+      if (res.ok) {
+        return (await res.json()) as T;
+      }
+
+      // 401 → refresh once and retry, otherwise mark needs-reauth and bail.
+      if (res.status === 401) {
+        if (refreshedOnce || opts.accessTokenOverride) {
+          await this.store.markNeedsReauth().catch(() => undefined);
+          throw new AuthError(
+            `TrueLayer ${method} ${path} returned 401 after refresh; connection needs re-consent.`,
+          );
+        }
+        refreshedOnce = true;
+        const fresh = await this.refreshTokens();
+        accessToken = fresh.accessToken;
+        continue;
+      }
+
+      // 403 → flagged for re-consent, no retry.
+      if (res.status === 403) {
+        await this.store.markNeedsReauth().catch(() => undefined);
+        const text = await safeReadText(res);
+        throw new AuthError(
+          `TrueLayer ${method} ${path} forbidden (403): ${truncate(text, 300)}. Re-link required.`,
+        );
+      }
+
+      // 429 → respect Retry-After then back off.
+      if (res.status === 429) {
+        if (attempt >= this.maxRetries) {
+          throw new RateLimitError(
+            `TrueLayer ${method} ${path} rate-limited (429) after ${this.maxRetries} retries.`,
+          );
+        }
+        const retryAfterHeader = res.headers.get('retry-after');
+        const retryAfterMs = parseRetryAfter(retryAfterHeader);
+        const backoff = retryAfterMs ?? this.backoff(attempt);
+        await this.sleepFn(backoff);
+        attempt += 1;
+        continue;
+      }
+
+      // 5xx → exponential backoff with jitter.
+      if (res.status >= 500 && res.status < 600) {
+        if (attempt >= this.maxRetries) {
+          const text = await safeReadText(res);
+          throw new NetworkError(
+            `TrueLayer ${method} ${path} failed (${res.status}) after ${this.maxRetries} retries: ${truncate(text, 300)}`,
+          );
+        }
+        await this.sleepFn(this.backoff(attempt));
+        attempt += 1;
+        continue;
+      }
+
+      // Other 4xx → terminal.
+      const text = await safeReadText(res);
+      const parsed = safeParseJson<TrueLayerErrorBody>(text);
+      const detail = parsed?.error_description ?? parsed?.message ?? text;
+      throw new NetworkError(
+        `TrueLayer ${method} ${path} failed (${res.status}): ${truncate(detail, 300)}`,
+      );
+    }
+  }
+
+  private backoff(attempt: number): number {
+    const expo = BACKOFF_BASE_MS * 2 ** attempt;
+    const jitter = expo * this.randomFn();
+    return Math.round(expo + jitter);
+  }
+}
+
+// ---------- Helpers ----------
+
+function withDateRange(path: string, range: TrueLayerDateRange): string {
+  if (!range.from && !range.to) return path;
+  const params = new URLSearchParams();
+  if (range.from) params.set('from', range.from);
+  if (range.to) params.set('to', range.to);
+  const sep = path.includes('?') ? '&' : '?';
+  return `${path}${sep}${params.toString()}`;
+}
+
+function parseRetryAfter(header: string | null): number | null {
+  if (!header) return null;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) return Math.round(seconds * 1000);
+  // Could be an HTTP-date.
+  const date = Date.parse(header);
+  if (!Number.isNaN(date)) {
+    const delta = date - Date.now();
+    return delta > 0 ? delta : 0;
+  }
+  return null;
+}
+
+async function safeReadText(res: Response): Promise<string> {
+  try {
+    return await res.text();
+  } catch {
+    return '';
+  }
+}
+
+function safeParseJson<T>(text: string): T | null {
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return null;
+  }
+}
+
+function truncate(s: string, n: number): string {
+  if (s.length <= n) return s;
+  return `${s.slice(0, n)}...`;
+}

--- a/src/types/truelayer.ts
+++ b/src/types/truelayer.ts
@@ -1,4 +1,140 @@
-// TODO(Phase 1, issue #2): TrueLayer API response types.
-export interface TrueLayerPlaceholder {
-  _placeholder: true;
+// TrueLayer Data API response types.
+// Based on https://docs.truelayer.com/docs/data-api-basics and PRD §8.1.
+
+export interface TrueLayerTokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  token_type: string;
+  scope?: string;
 }
+
+export interface TrueLayerMeResult {
+  client_id: string;
+  credentials_id: string;
+  consent_status?: string;
+  consent_created?: string;
+  consent_expires_at?: string;
+  provider: {
+    provider_id: string;
+    display_name: string;
+    logo_uri?: string;
+  };
+}
+
+export interface TrueLayerMeResponse {
+  results: TrueLayerMeResult[];
+}
+
+export interface TrueLayerProviderInfo {
+  display_name: string;
+  provider_id: string;
+  logo_uri?: string;
+}
+
+export interface TrueLayerAccountNumber {
+  iban?: string;
+  swift_bic?: string;
+  number?: string;
+  sort_code?: string;
+}
+
+export interface TrueLayerAccount {
+  account_id: string;
+  account_type: string; // TRANSACTION | SAVINGS
+  display_name: string;
+  currency: string;
+  account_number?: TrueLayerAccountNumber;
+  provider: TrueLayerProviderInfo;
+  update_timestamp?: string;
+}
+
+export interface TrueLayerAccountsResponse {
+  results: TrueLayerAccount[];
+}
+
+export interface TrueLayerBalance {
+  currency: string;
+  available?: number;
+  current: number;
+  overdraft?: number;
+  update_timestamp?: string;
+}
+
+export interface TrueLayerBalanceResponse {
+  results: TrueLayerBalance[];
+}
+
+export interface TrueLayerTransactionMeta {
+  provider_transaction_category?: string;
+  provider_reference?: string;
+  provider_category?: string;
+  provider_id?: string;
+  [k: string]: unknown;
+}
+
+export interface TrueLayerTransaction {
+  transaction_id: string;
+  timestamp: string;
+  description: string;
+  amount: number;
+  currency: string;
+  transaction_type: string; // DEBIT | CREDIT
+  transaction_category?: string;
+  transaction_classification?: string[];
+  merchant_name?: string;
+  running_balance?: { amount: number; currency: string };
+  meta?: TrueLayerTransactionMeta;
+  normalised_provider_transaction_id?: string;
+  provider_transaction_id?: string;
+}
+
+export interface TrueLayerTransactionsResponse {
+  results: TrueLayerTransaction[];
+}
+
+export interface TrueLayerCard {
+  account_id: string;
+  card_network: string;
+  card_type: string;
+  currency: string;
+  display_name: string;
+  partial_card_number?: string;
+  name_on_card?: string;
+  valid_from?: string;
+  valid_to?: string;
+  update_timestamp?: string;
+  provider: TrueLayerProviderInfo;
+}
+
+export interface TrueLayerCardsResponse {
+  results: TrueLayerCard[];
+}
+
+export interface TrueLayerCardBalance {
+  available: number;
+  current: number;
+  credit_limit?: number;
+  last_statement_balance?: number;
+  last_statement_date?: string;
+  payment_due?: number;
+  payment_due_date?: string;
+  currency: string;
+  update_timestamp?: string;
+}
+
+export interface TrueLayerCardBalanceResponse {
+  results: TrueLayerCardBalance[];
+}
+
+export interface TrueLayerErrorBody {
+  error?: string;
+  error_description?: string;
+  error_details?: unknown;
+  message?: string;
+}
+
+export type TrueLayerDateRange = {
+  from?: string; // ISO date or full timestamp
+  to?: string;
+};

--- a/tests/unit/keychain.test.ts
+++ b/tests/unit/keychain.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  type KeychainBackend,
+  SERVICE,
+  accountNames,
+  deleteAllForConnection,
+  deleteToken,
+  getToken,
+  setKeychainBackend,
+  setToken,
+} from '../../src/services/keychain';
+
+class InMemoryKeychain implements KeychainBackend {
+  private store = new Map<string, string>(); // key = `${service}::${account}`
+
+  private k(service: string, account: string): string {
+    return `${service}::${account}`;
+  }
+
+  async setPassword(service: string, account: string, password: string): Promise<void> {
+    this.store.set(this.k(service, account), password);
+  }
+
+  async getPassword(service: string, account: string): Promise<string | null> {
+    return this.store.get(this.k(service, account)) ?? null;
+  }
+
+  async deletePassword(service: string, account: string): Promise<boolean> {
+    return this.store.delete(this.k(service, account));
+  }
+
+  async findCredentials(service: string): Promise<Array<{ account: string; password: string }>> {
+    const prefix = `${service}::`;
+    const out: Array<{ account: string; password: string }> = [];
+    for (const [k, v] of this.store) {
+      if (k.startsWith(prefix)) out.push({ account: k.slice(prefix.length), password: v });
+    }
+    return out;
+  }
+}
+
+describe('keychain wrapper', () => {
+  let backend: InMemoryKeychain;
+  beforeEach(() => {
+    backend = new InMemoryKeychain();
+    setKeychainBackend(backend);
+  });
+  afterEach(() => {
+    setKeychainBackend(null);
+  });
+
+  test('setToken / getToken round-trips', async () => {
+    await setToken('truelayer:abc:access', 'shh');
+    expect(await getToken('truelayer:abc:access')).toBe('shh');
+  });
+
+  test('getToken returns null when not set', async () => {
+    expect(await getToken('missing')).toBeNull();
+  });
+
+  test('deleteToken removes the entry', async () => {
+    await setToken('x', '1');
+    expect(await deleteToken('x')).toBe(true);
+    expect(await getToken('x')).toBeNull();
+    expect(await deleteToken('x')).toBe(false);
+  });
+
+  test('account name helpers follow PRD §9.1 convention', () => {
+    expect(accountNames.access('CONN-1')).toBe('truelayer:CONN-1:access');
+    expect(accountNames.refresh('CONN-1')).toBe('truelayer:CONN-1:refresh');
+    expect(accountNames.trueLayerClientSecret).toBe('truelayer:client_secret');
+    expect(accountNames.anthropicApiKey).toBe('anthropic:api_key');
+  });
+
+  test('deleteAllForConnection removes only that connection’s entries', async () => {
+    await setToken(accountNames.access('a'), 'a-access');
+    await setToken(accountNames.refresh('a'), 'a-refresh');
+    await setToken(accountNames.expiry('a'), '1');
+    await setToken(accountNames.access('b'), 'b-access');
+    await setToken(accountNames.trueLayerClientSecret, 'cs');
+
+    const removed = await deleteAllForConnection('a');
+    expect(removed).toBe(3);
+
+    expect(await getToken(accountNames.access('a'))).toBeNull();
+    expect(await getToken(accountNames.refresh('a'))).toBeNull();
+    expect(await getToken(accountNames.access('b'))).toBe('b-access');
+    expect(await getToken(accountNames.trueLayerClientSecret)).toBe('cs');
+  });
+
+  test('SERVICE constant is the canonical "ferret"', () => {
+    expect(SERVICE).toBe('ferret');
+  });
+});

--- a/tests/unit/oauth-state.test.ts
+++ b/tests/unit/oauth-state.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { generateState, validateState } from '../../src/services/oauth';
+
+describe('oauth state', () => {
+  test('generateState returns a hex string of 2*bytes length', () => {
+    const s = generateState(32);
+    expect(s).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('generateState returns unique values across calls', () => {
+    const a = generateState();
+    const b = generateState();
+    expect(a).not.toBe(b);
+  });
+
+  test('validateState accepts the exact same token', () => {
+    const s = generateState(16);
+    expect(validateState(s, s)).toBe(true);
+  });
+
+  test('validateState rejects mismatched tokens', () => {
+    const s = generateState(16);
+    const wrong = generateState(16);
+    expect(validateState(s, wrong)).toBe(false);
+  });
+
+  test('validateState rejects null / undefined / empty', () => {
+    const s = generateState(16);
+    expect(validateState(s, null)).toBe(false);
+    expect(validateState(s, undefined)).toBe(false);
+    expect(validateState(s, '')).toBe(false);
+  });
+
+  test('validateState rejects different-length tokens', () => {
+    expect(validateState('aaaa', 'aaaab')).toBe(false);
+    expect(validateState('aaaab', 'aaaa')).toBe(false);
+  });
+
+  test('validateState rejects tokens that differ by one bit (CSRF guard)', () => {
+    expect(validateState('abcdef', 'abcdee')).toBe(false);
+  });
+});

--- a/tests/unit/truelayer-client.test.ts
+++ b/tests/unit/truelayer-client.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  type FetchLike,
+  type TokenBundle,
+  type TokenStore,
+  TrueLayerClient,
+} from '../../src/services/truelayer';
+
+interface FetchCall {
+  url: string;
+  init?: RequestInit;
+}
+
+interface ScriptedResponse {
+  status?: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+function mockFetch(responses: ScriptedResponse[]): { fetch: FetchLike; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const queue = [...responses];
+  const fetchImpl: FetchLike = async (input, init) => {
+    calls.push({ url: input.toString(), init });
+    const next = queue.shift();
+    if (!next) {
+      throw new Error(`No scripted response for ${input.toString()}`);
+    }
+    const status = next.status ?? 200;
+    const body = typeof next.body === 'string' ? next.body : JSON.stringify(next.body ?? {});
+    return new Response(body, {
+      status,
+      headers: { 'content-type': 'application/json', ...(next.headers ?? {}) },
+    });
+  };
+  return { fetch: fetchImpl, calls };
+}
+
+class StubStore implements TokenStore {
+  reauthCalls = 0;
+  saved: TokenBundle[] = [];
+  constructor(public bundle: TokenBundle) {}
+  async load() {
+    return this.bundle;
+  }
+  async save(b: TokenBundle) {
+    this.saved.push(b);
+    this.bundle = b;
+  }
+  async markNeedsReauth() {
+    this.reauthCalls += 1;
+  }
+}
+
+const credentials = { clientId: 'cid', clientSecret: 'csec' };
+
+function freshBundle(overrides: Partial<TokenBundle> = {}): TokenBundle {
+  return {
+    accessToken: 'access-1',
+    refreshToken: 'refresh-1',
+    expiresAtMs: Date.now() + 60 * 60 * 1000,
+    ...overrides,
+  };
+}
+
+describe('TrueLayerClient', () => {
+  test('parses /accounts response', async () => {
+    const store = new StubStore(freshBundle());
+    const accounts = [
+      {
+        account_id: 'a1',
+        account_type: 'TRANSACTION',
+        display_name: 'Lloyds Current',
+        currency: 'GBP',
+        provider: { provider_id: 'uk-ob-lloyds', display_name: 'Lloyds' },
+        account_number: { sort_code: '12-34-56', number: '12345678' },
+      },
+    ];
+    const { fetch, calls } = mockFetch([{ body: { results: accounts } }]);
+    const client = new TrueLayerClient({ credentials, store, fetch });
+    const resp = await client.getAccounts();
+    expect(resp.results).toHaveLength(1);
+    expect(resp.results[0]?.account_id).toBe('a1');
+    expect(calls[0]?.url).toContain('/data/v1/accounts');
+    expect((calls[0]?.init?.headers as Record<string, string>).authorization).toBe(
+      'Bearer access-1',
+    );
+  });
+
+  test('parses /accounts/:id/balance response', async () => {
+    const store = new StubStore(freshBundle());
+    const { fetch } = mockFetch([
+      { body: { results: [{ currency: 'GBP', current: 1234.56, available: 1200 }] } },
+    ]);
+    const client = new TrueLayerClient({ credentials, store, fetch });
+    const resp = await client.getAccountBalance('a1');
+    expect(resp.results[0]?.current).toBe(1234.56);
+  });
+
+  test('passes from/to as query params on transactions endpoint', async () => {
+    const store = new StubStore(freshBundle());
+    const { fetch, calls } = mockFetch([{ body: { results: [] } }]);
+    const client = new TrueLayerClient({ credentials, store, fetch });
+    await client.getAccountTransactions('a1', { from: '2026-01-01', to: '2026-02-01' });
+    expect(calls[0]?.url).toContain('from=2026-01-01');
+    expect(calls[0]?.url).toContain('to=2026-02-01');
+  });
+
+  test('refreshes on 401 then retries the original request', async () => {
+    const store = new StubStore(freshBundle({ accessToken: 'stale' }));
+    const { fetch, calls } = mockFetch([
+      { status: 401, body: { error: 'unauthorized' } },
+      // refresh response (POST /connect/token)
+      {
+        body: {
+          access_token: 'fresh',
+          refresh_token: 'r2',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        },
+      },
+      // retried original request
+      { body: { results: [] } },
+    ]);
+    const client = new TrueLayerClient({ credentials, store, fetch, sleep: async () => {} });
+    await client.getAccounts();
+    expect(calls).toHaveLength(3);
+    expect(calls[1]?.url).toContain('/connect/token');
+    expect(store.saved[0]?.accessToken).toBe('fresh');
+    expect((calls[2]?.init?.headers as Record<string, string>).authorization).toBe('Bearer fresh');
+  });
+
+  test('on second 401 surfaces AuthError and marks needs_reauth', async () => {
+    const store = new StubStore(freshBundle({ accessToken: 'stale' }));
+    const { fetch } = mockFetch([
+      { status: 401, body: { error: 'unauthorized' } },
+      {
+        body: {
+          access_token: 'fresh',
+          refresh_token: 'r2',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        },
+      },
+      { status: 401, body: { error: 'unauthorized again' } },
+    ]);
+    const client = new TrueLayerClient({ credentials, store, fetch, sleep: async () => {} });
+    await expect(client.getAccounts()).rejects.toThrow(/needs re-consent/);
+    expect(store.reauthCalls).toBe(1);
+  });
+
+  test('marks connection needing re-consent on 403 (no retry)', async () => {
+    const store = new StubStore(freshBundle());
+    const { fetch, calls } = mockFetch([{ status: 403, body: { error: 'forbidden' } }]);
+    const client = new TrueLayerClient({ credentials, store, fetch });
+    await expect(client.getAccounts()).rejects.toThrow(/forbidden/);
+    expect(store.reauthCalls).toBe(1);
+    expect(calls).toHaveLength(1);
+  });
+
+  test('retries on 429 respecting Retry-After (seconds), then succeeds', async () => {
+    const store = new StubStore(freshBundle());
+    const sleeps: number[] = [];
+    const { fetch, calls } = mockFetch([
+      { status: 429, headers: { 'retry-after': '2' }, body: { error: 'slow down' } },
+      { body: { results: [] } },
+    ]);
+    const client = new TrueLayerClient({
+      credentials,
+      store,
+      fetch,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+      random: () => 0,
+    });
+    await client.getAccounts();
+    expect(calls).toHaveLength(2);
+    expect(sleeps[0]).toBe(2000);
+  });
+
+  test('retries on 5xx with exponential backoff (250ms base)', async () => {
+    const store = new StubStore(freshBundle());
+    const sleeps: number[] = [];
+    const { fetch, calls } = mockFetch([
+      { status: 503, body: { error: 'down' } },
+      { status: 503, body: { error: 'down' } },
+      { body: { results: [] } },
+    ]);
+    const client = new TrueLayerClient({
+      credentials,
+      store,
+      fetch,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+      random: () => 0, // jitter contribution = 0
+    });
+    await client.getAccounts();
+    expect(calls).toHaveLength(3);
+    // attempt 0: base * 2^0 = 250ms; attempt 1: base * 2^1 = 500ms (no jitter w/ random=0)
+    expect(sleeps).toEqual([250, 500]);
+  });
+
+  test('gives up after maxRetries on persistent 5xx', async () => {
+    const store = new StubStore(freshBundle());
+    const { fetch } = mockFetch([
+      { status: 500, body: { error: 'boom' } },
+      { status: 500, body: { error: 'boom' } },
+      { status: 500, body: { error: 'boom' } },
+      { status: 500, body: { error: 'boom' } },
+    ]);
+    const client = new TrueLayerClient({
+      credentials,
+      store,
+      fetch,
+      sleep: async () => {},
+      random: () => 0,
+    });
+    await expect(client.getAccounts()).rejects.toThrow(/after 3 retries/);
+  });
+
+  test('proactively refreshes when token is within skew window', async () => {
+    const store = new StubStore(freshBundle({ expiresAtMs: Date.now() + 30_000 /* < 60s skew */ }));
+    const { fetch, calls } = mockFetch([
+      // refresh
+      {
+        body: {
+          access_token: 'fresh',
+          refresh_token: 'r2',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        },
+      },
+      // original
+      { body: { results: [] } },
+    ]);
+    const client = new TrueLayerClient({ credentials, store, fetch });
+    await client.getAccounts();
+    expect(calls[0]?.url).toContain('/connect/token');
+    expect(store.saved[0]?.accessToken).toBe('fresh');
+  });
+
+  test('exchangeAuthCode posts the right form fields', async () => {
+    const { fetch, calls } = mockFetch([
+      {
+        body: {
+          access_token: 'a',
+          refresh_token: 'r',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        },
+      },
+    ]);
+    const resp = await TrueLayerClient.exchangeAuthCode({
+      credentials,
+      code: 'AUTHCODE',
+      redirectUri: 'http://localhost:8765/callback',
+      fetch,
+    });
+    expect(resp.access_token).toBe('a');
+    const body = (calls[0]?.init?.body as string) ?? '';
+    expect(body).toContain('grant_type=authorization_code');
+    expect(body).toContain('code=AUTHCODE');
+    expect(body).toContain('client_id=cid');
+    expect(body).toContain('client_secret=csec');
+  });
+
+  test('parses transactions response with merchant + amount fields', async () => {
+    const store = new StubStore(freshBundle());
+    const { fetch } = mockFetch([
+      {
+        body: {
+          results: [
+            {
+              transaction_id: 't1',
+              timestamp: '2026-04-01T10:00:00Z',
+              description: 'PRET A MANGER',
+              amount: -4.5,
+              currency: 'GBP',
+              transaction_type: 'DEBIT',
+              merchant_name: 'Pret A Manger',
+            },
+          ],
+        },
+      },
+    ]);
+    const client = new TrueLayerClient({ credentials, store, fetch });
+    const resp = await client.getAccountTransactions('a1');
+    expect(resp.results[0]?.merchant_name).toBe('Pret A Manger');
+    expect(resp.results[0]?.amount).toBe(-4.5);
+  });
+});


### PR DESCRIPTION
Closes #2.

## Summary
- **`services/truelayer.ts`**: full API client surface from PRD §8.1 endpoints table (10 methods covering auth, accounts, balance, transactions, cards). Transparent token refresh (60s skew); 401-refresh-once / 403-mark-reauth / 429-Retry-After / 5xx exponential backoff with jitter (max 3 retries).
- **`services/oauth.ts`**: ephemeral local callback server on random port (8000-9999, 3-port-collision retry), 5-min timeout, 32-byte CSRF state token.
- **`services/keychain.ts`**: keytar wrapper with PRD §9.1 account naming. Test backend injection.
- **`lib/secrets.ts`**: keychain-first, env-var-fallback resolver.
- **`commands/link`**: end-to-end OAuth flow (browser open, code exchange, persist tokens to keychain, write `connections` + `accounts` rows).
- **`commands/unlink`**: clears keychain, marks `status='revoked'`, preserves accounts/transactions for audit.
- **`commands/connections`**: cli-table3 listing with `<7-day` expiry warning in yellow.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun run check` passes
- [x] `bun test` — **29 pass, 0 fail, 142 expect() calls** (25 new)
- [x] `HOME=$(mktemp -d) bun run src/cli.ts init` exit 0
- [x] `bun run src/cli.ts connections` (empty DB) exit 0, prints empty table + hint
- [x] `bun run src/cli.ts link --help` shows `--provider`, `--scope`, `--timeout`
- [ ] **Real OAuth flow not tested end-to-end** — requires live TrueLayer credentials

## For Phase 2 (sync) consumption
The full `TrueLayerClient` is ready: `getAccounts()`, `getAccountBalance(id)`, `getAccountTransactions(id, {from, to})`, `getPendingTransactions(id)`, `getCards()`, `getCardBalance(id)`, `getCardTransactions(id, {from, to})`. Pass it a `TokenStore` (`load`/`save`/`markNeedsReauth`); the client transparently refreshes tokens and persists via `store.save()`. **No need to extend the client for Phase 2.**

## Untouched files (per parallel-agent contract)
`src/cli.ts`, `src/commands/index.ts`, `src/db/schema.ts`, `package.json`, configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)