### PR TITLE
feat: Phase 3 — list and filter transactions (`ferret ls`)

### DIFF
--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -1,24 +1,151 @@
 import { defineCommand } from 'citty';
-import { notImplemented } from '../lib/errors';
+import {
+  type ListFilters,
+  type ListSortField,
+  type TransactionRow,
+  listTransactions,
+} from '../db/queries/list';
+import { formatDate, parseDate, parseDuration } from '../lib/dates';
+import { ValidationError } from '../lib/errors';
+import { formatCsv, formatJson, formatTable, isTty } from '../lib/format';
+
+const VALID_SORT_FIELDS: readonly ListSortField[] = ['timestamp', 'amount', 'merchant', 'category'];
 
 export default defineCommand({
   meta: { name: 'ls', description: 'List transactions with filters' },
   args: {
-    since: { type: 'string', description: 'Lower-bound date or duration' },
-    until: { type: 'string', description: 'Upper-bound date' },
-    category: { type: 'string', description: 'Filter by category' },
+    since: {
+      type: 'string',
+      description: 'Lower-bound date or duration (e.g. 30d, 2w, 2026-01-01)',
+    },
+    until: { type: 'string', description: 'Upper-bound date (yyyy-MM-dd)' },
+    category: { type: 'string', description: 'Filter by category name (exact)' },
     merchant: { type: 'string', description: 'Substring match on merchant' },
-    account: { type: 'string', description: 'Account id or name' },
+    account: { type: 'string', description: 'Account id or display name' },
     min: { type: 'string', description: 'Minimum absolute amount' },
     max: { type: 'string', description: 'Maximum absolute amount' },
-    incoming: { type: 'boolean', description: 'Only incoming' },
-    outgoing: { type: 'boolean', description: 'Only outgoing' },
+    incoming: { type: 'boolean', description: 'Only incoming transactions' },
+    outgoing: { type: 'boolean', description: 'Only outgoing transactions' },
     limit: { type: 'string', description: 'Max rows (default 50)' },
-    json: { type: 'boolean', description: 'JSON output' },
-    csv: { type: 'boolean', description: 'CSV output' },
-    sort: { type: 'string', description: 'Sort field (default timestamp desc)' },
+    json: { type: 'boolean', description: 'Output JSON (stable schema)' },
+    csv: { type: 'boolean', description: 'Output CSV (RFC 4180)' },
+    sort: {
+      type: 'string',
+      description: 'Sort field (default timestamp.desc). Format: <field>[.asc|.desc]',
+    },
   },
-  run() {
-    notImplemented('ls', 4);
+  run({ args }) {
+    if (args.incoming && args.outgoing) {
+      throw new ValidationError('--incoming and --outgoing are mutually exclusive');
+    }
+
+    const filters: ListFilters = {};
+    if (typeof args.since === 'string' && args.since.length > 0) {
+      filters.since = parseDuration(args.since);
+    }
+    if (typeof args.until === 'string' && args.until.length > 0) {
+      filters.until = parseDate(args.until);
+    }
+    if (typeof args.category === 'string' && args.category.length > 0) {
+      filters.category = args.category;
+    }
+    if (typeof args.merchant === 'string' && args.merchant.length > 0) {
+      filters.merchant = args.merchant;
+    }
+    if (typeof args.account === 'string' && args.account.length > 0) {
+      filters.accountId = args.account;
+    }
+    if (typeof args.min === 'string' && args.min.length > 0) {
+      filters.min = parseAmount('--min', args.min);
+    }
+    if (typeof args.max === 'string' && args.max.length > 0) {
+      filters.max = parseAmount('--max', args.max);
+    }
+    if (args.incoming) filters.direction = 'incoming';
+    if (args.outgoing) filters.direction = 'outgoing';
+    if (typeof args.limit === 'string' && args.limit.length > 0) {
+      filters.limit = parseLimit(args.limit);
+    }
+    if (typeof args.sort === 'string' && args.sort.length > 0) {
+      filters.sort = parseSort(args.sort);
+    }
+
+    const rows = listTransactions(filters);
+
+    if (args.json) {
+      process.stdout.write(`${formatJson(rows.map(toSerializable))}\n`);
+      return;
+    }
+    if (args.csv) {
+      process.stdout.write(`${formatCsv(rows.map(toSerializable))}\n`);
+      return;
+    }
+
+    if (rows.length === 0) {
+      process.stdout.write('no transactions match the given filters\n');
+      return;
+    }
+
+    const display = rows.map((r) => ({
+      date: formatDate(r.timestamp),
+      account: r.accountName ?? r.accountId,
+      merchant: r.merchantName ?? r.description,
+      category: r.category ?? '',
+      amount: formatAmountForRow(r.amount, r.currency),
+    }));
+
+    if (isTty()) {
+      process.stdout.write(`${formatTable(display)}\n`);
+    } else {
+      // Plain TSV-ish output for pipes when neither --json nor --csv is set:
+      // tabular but stripped of borders/colors so awk and cut stay happy.
+      process.stdout.write(`${formatTable(display, { colors: false })}\n`);
+    }
   },
 });
+
+function parseAmount(flag: string, raw: string): number {
+  const n = Number.parseFloat(raw);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new ValidationError(`${flag} must be a non-negative number, got "${raw}"`);
+  }
+  return n;
+}
+
+function parseLimit(raw: string): number {
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new ValidationError(`--limit must be a positive integer, got "${raw}"`);
+  }
+  return n;
+}
+
+function parseSort(raw: string): { field: ListSortField; dir: 'asc' | 'desc' } {
+  const [fieldRaw, dirRaw = 'desc'] = raw.split('.');
+  const field = fieldRaw as ListSortField;
+  if (!VALID_SORT_FIELDS.includes(field)) {
+    throw new ValidationError(
+      `Invalid --sort field "${fieldRaw ?? ''}". Allowed: ${VALID_SORT_FIELDS.join(', ')}`,
+    );
+  }
+  if (dirRaw !== 'asc' && dirRaw !== 'desc') {
+    throw new ValidationError(`Invalid --sort direction "${dirRaw}". Allowed: asc, desc`);
+  }
+  return { field, dir: dirRaw };
+}
+
+// Format an amount for table display without going through formatCurrency
+// (which uses Intl + colors). For tables we want compact numbers and a
+// currency suffix; the colored version is used in summaries.
+function formatAmountForRow(amount: number, currency: string): string {
+  const sign = amount < 0 ? '-' : '';
+  const abs = Math.abs(amount).toFixed(2);
+  return `${sign}${abs} ${currency}`;
+}
+
+function toSerializable(row: TransactionRow): Record<string, unknown> {
+  return {
+    ...row,
+    timestamp: row.timestamp instanceof Date ? row.timestamp.toISOString() : row.timestamp,
+  };
+}

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -73,11 +73,15 @@ export default defineCommand({
     const rows = listTransactions(filters);
 
     if (args.json) {
+      // formatJson([]) emits `[]`, which is the correct empty payload.
       process.stdout.write(`${formatJson(rows.map(toSerializable))}\n`);
       return;
     }
     if (args.csv) {
-      process.stdout.write(`${formatCsv(rows.map(toSerializable))}\n`);
+      // For CSV, an empty row set should still emit the header line so
+      // downstream tools can detect the columns.
+      const csv = rows.length === 0 ? CSV_HEADER : formatCsv(rows.map(toSerializable));
+      process.stdout.write(`${csv}\n`);
       return;
     }
 
@@ -113,8 +117,10 @@ function parseAmount(flag: string, raw: string): number {
 }
 
 function parseLimit(raw: string): number {
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n <= 0) {
+  // `Number.parseInt('3.9', 10)` would silently truncate to 3, so we route
+  // through `Number()` first and require an integer result.
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
     throw new ValidationError(`--limit must be a positive integer, got "${raw}"`);
   }
   return n;
@@ -144,8 +150,26 @@ function formatAmountForRow(amount: number, currency: string): string {
 }
 
 function toSerializable(row: TransactionRow): Record<string, unknown> {
+  // `TransactionRow.timestamp` is typed as `Date`, so a defensive
+  // `instanceof Date` branch was previously dead code.
   return {
     ...row,
-    timestamp: row.timestamp instanceof Date ? row.timestamp.toISOString() : row.timestamp,
+    timestamp: row.timestamp.toISOString(),
   };
 }
+
+// Pre-computed CSV header line that mirrors the field order produced by
+// `toSerializable`. Used when there are no rows to render so the output is
+// still a valid CSV with the expected column set.
+const CSV_HEADER = [
+  'id',
+  'accountId',
+  'accountName',
+  'timestamp',
+  'amount',
+  'currency',
+  'description',
+  'merchantName',
+  'category',
+  'transactionType',
+].join(',');

--- a/src/db/queries/list.ts
+++ b/src/db/queries/list.ts
@@ -3,7 +3,7 @@
 // txn_category_idx, txn_merchant_idx) so we hit the perf target of < 200ms on
 // 100k rows (PRD §11.1). We never SELECT * and filter in JS.
 
-import { type SQL, and, asc, desc, eq, gte, like, lte, or } from 'drizzle-orm';
+import { type SQL, and, asc, desc, eq, gt, gte, lt, lte, or, sql } from 'drizzle-orm';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import { ValidationError } from '../../lib/errors';
 import { db as defaultDb } from '../client';
@@ -70,8 +70,11 @@ export function listTransactions(
   if (filters.merchant && filters.merchant.length > 0) {
     // Case-insensitive substring match. SQLite's LIKE is case-insensitive for
     // ASCII by default; that's good enough for merchant names.
+    // We escape the LIKE metacharacters with a backslash and tell SQLite to
+    // treat `\` as the ESCAPE character so user input like `Amazon_Prime`
+    // matches the literal underscore rather than any single character.
     const pattern = `%${escapeLike(filters.merchant)}%`;
-    conditions.push(like(transactions.merchantName, pattern));
+    conditions.push(sql`${transactions.merchantName} LIKE ${pattern} ESCAPE '\\'`);
   }
   if (filters.accountId && filters.accountId.length > 0) {
     // Match against either accounts.id (UUID) or accounts.displayName.
@@ -103,10 +106,12 @@ export function listTransactions(
     );
     if (maxFilter) conditions.push(maxFilter);
   }
+  // A £0 transaction is neither inflow nor outflow, so direction filters use
+  // strict comparisons and exclude zero-amount rows from both buckets.
   if (filters.direction === 'incoming') {
-    conditions.push(gte(transactions.amount, 0));
+    conditions.push(gt(transactions.amount, 0));
   } else if (filters.direction === 'outgoing') {
-    conditions.push(lte(transactions.amount, 0));
+    conditions.push(lt(transactions.amount, 0));
   }
 
   const sort = filters.sort ?? { field: 'timestamp' as const, dir: 'desc' as const };
@@ -146,7 +151,13 @@ function clampLimit(limit: number | undefined): number {
   if (!Number.isFinite(limit) || limit <= 0) {
     throw new ValidationError(`--limit must be a positive integer, got ${limit}`);
   }
-  return Math.min(Math.floor(limit), MAX_LIMIT);
+  const floored = Math.floor(limit);
+  if (floored > MAX_LIMIT) {
+    throw new ValidationError(
+      `--limit ${floored} exceeds the maximum of ${MAX_LIMIT}. Lower the limit and re-run.`,
+    );
+  }
+  return floored;
 }
 
 function resolveSortColumn(field: ListSortField) {
@@ -167,7 +178,10 @@ function resolveSortColumn(field: ListSortField) {
 }
 
 function escapeLike(input: string): string {
-  // We don't currently use an ESCAPE clause; strip the LIKE metacharacters
-  // (% and _) so they're treated as literals in user input.
-  return input.replace(/[\\%_]/g, '');
+  // Escape LIKE metacharacters so user input like `Amazon_Prime` is matched
+  // literally rather than treating `_` as a single-char wildcard. The order
+  // matters: backslash must be escaped first so we don't double-escape the
+  // backslashes we add for `%` and `_`. The caller pairs this with
+  // `LIKE ... ESCAPE '\\'` so SQLite knows `\` is the escape character.
+  return input.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
 }

--- a/src/db/queries/list.ts
+++ b/src/db/queries/list.ts
@@ -1,0 +1,173 @@
+// Query builder for `ferret ls`. All filtering happens in SQL using the
+// indexes declared on `transactions` (see schema.ts: txn_account_timestamp_idx,
+// txn_category_idx, txn_merchant_idx) so we hit the perf target of < 200ms on
+// 100k rows (PRD §11.1). We never SELECT * and filter in JS.
+
+import { type SQL, and, asc, desc, eq, gte, like, lte, or } from 'drizzle-orm';
+import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import { ValidationError } from '../../lib/errors';
+import { db as defaultDb } from '../client';
+import { accounts, transactions } from '../schema';
+import type * as schema from '../schema';
+
+export type ListSortField = 'timestamp' | 'amount' | 'merchant' | 'category';
+export type ListSortDir = 'asc' | 'desc';
+
+export interface ListFilters {
+  since?: Date;
+  until?: Date;
+  category?: string;
+  merchant?: string;
+  /** Account UUID (TrueLayer id) or display name. Matched against either. */
+  accountId?: string;
+  /** Lower bound on |amount| (absolute value). */
+  min?: number;
+  /** Upper bound on |amount| (absolute value). */
+  max?: number;
+  direction?: 'incoming' | 'outgoing';
+  limit?: number;
+  sort?: { field: ListSortField; dir: ListSortDir };
+}
+
+export interface TransactionRow {
+  id: string;
+  accountId: string;
+  accountName: string | null;
+  timestamp: Date;
+  amount: number;
+  currency: string;
+  description: string;
+  merchantName: string | null;
+  category: string | null;
+  transactionType: string | null;
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 10_000;
+
+/**
+ * Run a filtered, sorted, paged query against `transactions`. The result set is
+ * a stable view (`TransactionRow[]`) joined with the parent account so callers
+ * can render an account display name without a second round-trip.
+ *
+ * Pass a `db` instance for testing; defaults to the shared singleton.
+ */
+export function listTransactions(
+  filters: ListFilters = {},
+  db: BunSQLiteDatabase<typeof schema> = defaultDb,
+): TransactionRow[] {
+  const conditions: SQL[] = [];
+
+  if (filters.since instanceof Date) {
+    conditions.push(gte(transactions.timestamp, filters.since));
+  }
+  if (filters.until instanceof Date) {
+    conditions.push(lte(transactions.timestamp, filters.until));
+  }
+  if (filters.category && filters.category.length > 0) {
+    conditions.push(eq(transactions.category, filters.category));
+  }
+  if (filters.merchant && filters.merchant.length > 0) {
+    // Case-insensitive substring match. SQLite's LIKE is case-insensitive for
+    // ASCII by default; that's good enough for merchant names.
+    const pattern = `%${escapeLike(filters.merchant)}%`;
+    conditions.push(like(transactions.merchantName, pattern));
+  }
+  if (filters.accountId && filters.accountId.length > 0) {
+    // Match against either accounts.id (UUID) or accounts.displayName.
+    const accountFilter = or(
+      eq(accounts.id, filters.accountId),
+      eq(accounts.displayName, filters.accountId),
+    );
+    if (accountFilter) conditions.push(accountFilter);
+  }
+  if (typeof filters.min === 'number') {
+    if (!Number.isFinite(filters.min) || filters.min < 0) {
+      throw new ValidationError(`--min must be a non-negative number, got ${filters.min}`);
+    }
+    // |amount| >= min  =>  amount >= min OR amount <= -min
+    const minFilter = or(
+      gte(transactions.amount, filters.min),
+      lte(transactions.amount, -filters.min),
+    );
+    if (minFilter) conditions.push(minFilter);
+  }
+  if (typeof filters.max === 'number') {
+    if (!Number.isFinite(filters.max) || filters.max < 0) {
+      throw new ValidationError(`--max must be a non-negative number, got ${filters.max}`);
+    }
+    // |amount| <= max  =>  amount <= max AND amount >= -max
+    const maxFilter = and(
+      lte(transactions.amount, filters.max),
+      gte(transactions.amount, -filters.max),
+    );
+    if (maxFilter) conditions.push(maxFilter);
+  }
+  if (filters.direction === 'incoming') {
+    conditions.push(gte(transactions.amount, 0));
+  } else if (filters.direction === 'outgoing') {
+    conditions.push(lte(transactions.amount, 0));
+  }
+
+  const sort = filters.sort ?? { field: 'timestamp' as const, dir: 'desc' as const };
+  const sortColumn = resolveSortColumn(sort.field);
+  const orderBy = sort.dir === 'asc' ? asc(sortColumn) : desc(sortColumn);
+
+  const limit = clampLimit(filters.limit);
+
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const rows = db
+    .select({
+      id: transactions.id,
+      accountId: transactions.accountId,
+      accountName: accounts.displayName,
+      timestamp: transactions.timestamp,
+      amount: transactions.amount,
+      currency: transactions.currency,
+      description: transactions.description,
+      merchantName: transactions.merchantName,
+      category: transactions.category,
+      transactionType: transactions.transactionType,
+    })
+    .from(transactions)
+    .leftJoin(accounts, eq(transactions.accountId, accounts.id))
+    .where(where)
+    .orderBy(orderBy)
+    .limit(limit)
+    .all();
+
+  // Drizzle returns plain objects already; we only need to assert the shape.
+  return rows as TransactionRow[];
+}
+
+function clampLimit(limit: number | undefined): number {
+  if (limit === undefined) return DEFAULT_LIMIT;
+  if (!Number.isFinite(limit) || limit <= 0) {
+    throw new ValidationError(`--limit must be a positive integer, got ${limit}`);
+  }
+  return Math.min(Math.floor(limit), MAX_LIMIT);
+}
+
+function resolveSortColumn(field: ListSortField) {
+  switch (field) {
+    case 'timestamp':
+      return transactions.timestamp;
+    case 'amount':
+      return transactions.amount;
+    case 'merchant':
+      return transactions.merchantName;
+    case 'category':
+      return transactions.category;
+    default: {
+      const _exhaustive: never = field;
+      throw new ValidationError(`Unknown sort field: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+function escapeLike(input: string): string {
+  // We don't currently use an ESCAPE clause; strip the LIKE metacharacters
+  // (% and _) so they're treated as literals in user input.
+  return input.replace(/[\\%_]/g, '');
+}

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -121,5 +121,17 @@ export function formatDate(d: Date, fmt = 'yyyy-MM-dd'): string {
     const day = d.getUTCDate().toString().padStart(2, '0');
     return `${y}-${m}-${day}`;
   }
-  return dfFormat(d, fmt);
+  // date-fns' `format` reads the Date's *local* fields. To stay UTC-consistent
+  // with the rest of this library we build a shim Date whose local fields
+  // mirror the original UTC fields, then hand that to date-fns.
+  const utcShim = new Date(
+    d.getUTCFullYear(),
+    d.getUTCMonth(),
+    d.getUTCDate(),
+    d.getUTCHours(),
+    d.getUTCMinutes(),
+    d.getUTCSeconds(),
+    d.getUTCMilliseconds(),
+  );
+  return dfFormat(utcShim, fmt);
 }

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -1,2 +1,125 @@
-// TODO(Phase 3, issue #4): UTC-safe date utils + duration parsing (e.g. "30d", "2w").
-export {};
+// UTC-safe date utilities and duration parsing.
+//
+// These helpers back the `--since` / `--until` flags on `ferret ls` (and will be
+// reused by `sync`, `export`, and `budget` in later phases). All date math is
+// done in UTC so a user querying "last 30 days" never gets shifted by their
+// local timezone offset.
+
+import { format as dfFormat } from 'date-fns/format';
+import { ValidationError } from './errors';
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const DURATION_RE = /^(\d+)([dwmy])$/;
+
+/**
+ * Parse a duration string into a `Date` representing "now minus the duration",
+ * or, when given an ISO yyyy-MM-dd string, the absolute date at UTC midnight.
+ *
+ * Accepted forms:
+ *   - `30d` (days)
+ *   - `2w`  (weeks)
+ *   - `6m`  (calendar months)
+ *   - `2y`  (calendar years)
+ *   - `2026-01-01` (absolute, treated as UTC midnight)
+ *
+ * Throws `ValidationError` on unrecognized input.
+ */
+export function parseDuration(input: string, now: Date = new Date()): Date {
+  if (typeof input !== 'string' || input.length === 0) {
+    throw new ValidationError(`Invalid duration: ${JSON.stringify(input)}`);
+  }
+  const trimmed = input.trim();
+
+  if (ISO_DATE_RE.test(trimmed)) {
+    return parseDate(trimmed);
+  }
+
+  const m = DURATION_RE.exec(trimmed);
+  if (!m) {
+    throw new ValidationError(
+      `Invalid duration "${input}". Expected forms like "30d", "2w", "6m", "1y", or an ISO date "yyyy-MM-dd".`,
+    );
+  }
+  const n = Number.parseInt(m[1] ?? '', 10);
+  const unit = m[2];
+  if (!Number.isFinite(n) || n < 0) {
+    throw new ValidationError(
+      `Invalid duration "${input}": numeric component must be non-negative`,
+    );
+  }
+
+  // All math in UTC to stay timezone-stable.
+  const y = now.getUTCFullYear();
+  const mo = now.getUTCMonth();
+  const d = now.getUTCDate();
+  const h = now.getUTCHours();
+  const mi = now.getUTCMinutes();
+  const s = now.getUTCSeconds();
+  const ms = now.getUTCMilliseconds();
+
+  switch (unit) {
+    case 'd':
+      return new Date(Date.UTC(y, mo, d - n, h, mi, s, ms));
+    case 'w':
+      return new Date(Date.UTC(y, mo, d - n * 7, h, mi, s, ms));
+    case 'm':
+      return new Date(Date.UTC(y, mo - n, d, h, mi, s, ms));
+    case 'y':
+      return new Date(Date.UTC(y - n, mo, d, h, mi, s, ms));
+    default:
+      // Unreachable thanks to the regex, but the strict compiler wants it.
+      throw new ValidationError(`Invalid duration unit "${unit ?? ''}"`);
+  }
+}
+
+/**
+ * Parse a strict `yyyy-MM-dd` calendar date and return a UTC-midnight `Date`.
+ * Throws `ValidationError` for any other format or for impossible dates
+ * (e.g. `2025-02-30`).
+ */
+export function parseDate(input: string): Date {
+  if (typeof input !== 'string' || !ISO_DATE_RE.test(input)) {
+    throw new ValidationError(
+      `Invalid date "${String(input)}". Expected yyyy-MM-dd (e.g. 2026-04-19).`,
+    );
+  }
+  const parts = input.split('-');
+  const y = Number.parseInt(parts[0] ?? '', 10);
+  const mo = Number.parseInt(parts[1] ?? '', 10);
+  const d = Number.parseInt(parts[2] ?? '', 10);
+  if (!Number.isFinite(y) || !Number.isFinite(mo) || !Number.isFinite(d)) {
+    throw new ValidationError(`Invalid date "${input}"`);
+  }
+  if (mo < 1 || mo > 12 || d < 1 || d > 31) {
+    throw new ValidationError(`Invalid date "${input}"`);
+  }
+  const ms = Date.UTC(y, mo - 1, d, 0, 0, 0, 0);
+  const out = new Date(ms);
+  // Reject dates that round-tripped to something else (e.g. Feb 30 -> Mar 2).
+  if (out.getUTCFullYear() !== y || out.getUTCMonth() !== mo - 1 || out.getUTCDate() !== d) {
+    throw new ValidationError(`Invalid calendar date "${input}"`);
+  }
+  return out;
+}
+
+/**
+ * Format a `Date` for display. Defaults to `yyyy-MM-dd` per PRD §5.4.
+ *
+ * date-fns' `format` is locale/TZ-aware; we always feed it a `Date` whose UTC
+ * fields are the source of truth, so the rendered output is deterministic
+ * across machines for date-only patterns.
+ */
+export function formatDate(d: Date, fmt = 'yyyy-MM-dd'): string {
+  if (!(d instanceof Date) || Number.isNaN(d.getTime())) {
+    throw new ValidationError('formatDate: not a valid Date');
+  }
+  // For the default date-only format, work off the UTC components so the
+  // displayed day matches the stored UTC midnight regardless of local TZ.
+  if (fmt === 'yyyy-MM-dd') {
+    const y = d.getUTCFullYear().toString().padStart(4, '0');
+    const m = (d.getUTCMonth() + 1).toString().padStart(2, '0');
+    const day = d.getUTCDate().toString().padStart(2, '0');
+    return `${y}-${m}-${day}`;
+  }
+  return dfFormat(d, fmt);
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,2 +1,147 @@
-// TODO(Phase 3, issue #4): currency / table / progress-bar formatters.
-export {};
+// Output formatters for `ferret ls` (and any other command that needs a
+// table / JSON / CSV view). All functions are pure and TTY-aware where
+// applicable so the same row data renders correctly to both terminals and
+// pipelines.
+
+import Table from 'cli-table3';
+import pc from 'picocolors';
+
+export interface TableOptions {
+  /** Explicit column header order. Defaults to the keys of the first row. */
+  head?: string[];
+  /** Force-disable colors regardless of TTY (useful for tests). */
+  colors?: boolean;
+}
+
+/** Reports whether stdout is connected to an interactive terminal. */
+export function isTty(): boolean {
+  return Boolean(process.stdout.isTTY);
+}
+
+/**
+ * Format a numeric amount as a localized currency string. When the number is
+ * negative AND we're rendering to a TTY, the result is wrapped in red so it
+ * stands out as an outflow. Pipes/files get plain text.
+ */
+export function formatCurrency(amount: number, currency: string): string {
+  if (!Number.isFinite(amount)) {
+    return String(amount);
+  }
+  let formatted: string;
+  try {
+    formatted = new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency,
+    }).format(amount);
+  } catch {
+    // Unknown currency code — fall back to a sensible plain rendering rather
+    // than throwing inside a formatter.
+    formatted = `${amount.toFixed(2)} ${currency}`;
+  }
+  if (amount < 0 && isTty() && pc.isColorSupported) {
+    return pc.red(formatted);
+  }
+  return formatted;
+}
+
+/**
+ * Render an array of row objects as a unicode-bordered table. When stdout is
+ * not a TTY (or `colors: false`), the table is rendered with ASCII-only
+ * borders and no styling so it stays grep-friendly.
+ */
+export function formatTable(rows: Record<string, unknown>[], options: TableOptions = {}): string {
+  if (rows.length === 0) return '';
+  const head = options.head ?? Object.keys(rows[0] as Record<string, unknown>);
+  const useColors = options.colors ?? isTty();
+
+  const tableOpts: ConstructorParameters<typeof Table>[0] = useColors
+    ? { head }
+    : {
+        head,
+        // Plain ASCII borders + no styling so piped output is reproducible.
+        chars: {
+          top: '-',
+          'top-mid': '+',
+          'top-left': '+',
+          'top-right': '+',
+          bottom: '-',
+          'bottom-mid': '+',
+          'bottom-left': '+',
+          'bottom-right': '+',
+          left: '|',
+          'left-mid': '+',
+          mid: '-',
+          'mid-mid': '+',
+          right: '|',
+          'right-mid': '+',
+          middle: '|',
+        },
+        style: { head: [], border: [] },
+      };
+
+  const table = new Table(tableOpts);
+  for (const row of rows) {
+    table.push(head.map((k) => stringifyCell((row as Record<string, unknown>)[k])));
+  }
+  return table.toString();
+}
+
+/**
+ * Stable JSON serialization: keys sorted recursively so consumers (jq, diff,
+ * snapshot tests) get byte-deterministic output across runs.
+ */
+export function formatJson(rows: unknown): string {
+  return JSON.stringify(sortKeys(rows), null, 2);
+}
+
+/**
+ * Serialize an array of row objects as RFC 4180 CSV.
+ * - Header row derived from the union of keys in row order of first appearance.
+ * - Fields containing `,`, `"`, `\r`, or `\n` are wrapped in double quotes.
+ * - Embedded `"` is escaped as `""`.
+ * - `null` / `undefined` render as empty fields.
+ */
+export function formatCsv(rows: Record<string, unknown>[]): string {
+  if (rows.length === 0) return '';
+  const headers: string[] = [];
+  const seen = new Set<string>();
+  for (const row of rows) {
+    for (const k of Object.keys(row)) {
+      if (!seen.has(k)) {
+        seen.add(k);
+        headers.push(k);
+      }
+    }
+  }
+  const lines: string[] = [headers.map(csvEscape).join(',')];
+  for (const row of rows) {
+    lines.push(headers.map((h) => csvEscape(stringifyCell(row[h]))).join(','));
+  }
+  return lines.join('\r\n');
+}
+
+function csvEscape(value: string): string {
+  if (/[",\r\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function stringifyCell(v: unknown): string {
+  if (v === null || v === undefined) return '';
+  if (v instanceof Date) return v.toISOString();
+  if (typeof v === 'object') return JSON.stringify(v);
+  return String(v);
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value && typeof value === 'object' && !(value instanceof Date)) {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      out[key] = sortKeys((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}

--- a/tests/unit/dates.test.ts
+++ b/tests/unit/dates.test.ts
@@ -106,6 +106,13 @@ describe('formatDate', () => {
     expect(formatDate(d, 'yyyy/MM/dd')).toMatch(/2026\/04\/19/);
   });
 
+  test('custom format uses UTC components, not local timezone', () => {
+    // 2026-04-19T23:30:00Z renders as the same calendar day everywhere even
+    // though `new Date(...).getDate()` shifts in many local timezones.
+    const d = new Date(Date.UTC(2026, 3, 19, 23, 30, 0));
+    expect(formatDate(d, 'yyyy-MM-dd HH:mm')).toBe('2026-04-19 23:30');
+  });
+
   test('throws on invalid Date', () => {
     expect(() => formatDate(new Date('not-a-date'))).toThrow(ValidationError);
   });

--- a/tests/unit/dates.test.ts
+++ b/tests/unit/dates.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'bun:test';
+import { formatDate, parseDate, parseDuration } from '../../src/lib/dates';
+import { ValidationError } from '../../src/lib/errors';
+
+describe('parseDuration', () => {
+  const NOW = new Date(Date.UTC(2026, 3, 19, 12, 0, 0)); // 2026-04-19T12:00:00Z
+
+  test('parses days', () => {
+    const result = parseDuration('30d', NOW);
+    expect(result.toISOString()).toBe('2026-03-20T12:00:00.000Z');
+  });
+
+  test('parses weeks', () => {
+    const result = parseDuration('2w', NOW);
+    expect(result.toISOString()).toBe('2026-04-05T12:00:00.000Z');
+  });
+
+  test('parses months', () => {
+    const result = parseDuration('6m', NOW);
+    expect(result.getUTCFullYear()).toBe(2025);
+    expect(result.getUTCMonth()).toBe(9); // October (0-indexed)
+    expect(result.getUTCDate()).toBe(19);
+  });
+
+  test('parses years', () => {
+    const result = parseDuration('2y', NOW);
+    expect(result.getUTCFullYear()).toBe(2024);
+    expect(result.getUTCMonth()).toBe(3);
+    expect(result.getUTCDate()).toBe(19);
+  });
+
+  test('parses ISO date as absolute', () => {
+    const result = parseDuration('2026-01-01', NOW);
+    expect(result.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  test('handles zero duration', () => {
+    const result = parseDuration('0d', NOW);
+    expect(result.getTime()).toBe(NOW.getTime());
+  });
+
+  test('throws on bad input', () => {
+    expect(() => parseDuration('hello')).toThrow(ValidationError);
+    expect(() => parseDuration('')).toThrow(ValidationError);
+    expect(() => parseDuration('30')).toThrow(ValidationError);
+    expect(() => parseDuration('30x')).toThrow(ValidationError);
+    expect(() => parseDuration('-30d')).toThrow(ValidationError);
+  });
+
+  test('is timezone-stable', () => {
+    // Whatever local timezone we're in, parseDuration('30d', NOW) should return
+    // a Date whose UTC time is exactly 30 * 86400 seconds before NOW.
+    const result = parseDuration('30d', NOW);
+    expect(NOW.getTime() - result.getTime()).toBe(30 * 86_400 * 1000);
+  });
+});
+
+describe('parseDate', () => {
+  test('parses yyyy-MM-dd at UTC midnight', () => {
+    const d = parseDate('2026-04-19');
+    expect(d.toISOString()).toBe('2026-04-19T00:00:00.000Z');
+  });
+
+  test('handles leap years', () => {
+    const d = parseDate('2024-02-29');
+    expect(d.toISOString()).toBe('2024-02-29T00:00:00.000Z');
+  });
+
+  test('rejects non-leap-year Feb 29', () => {
+    expect(() => parseDate('2025-02-29')).toThrow(ValidationError);
+  });
+
+  test('rejects Feb 30', () => {
+    expect(() => parseDate('2025-02-30')).toThrow(ValidationError);
+  });
+
+  test('rejects bad format', () => {
+    expect(() => parseDate('2026/04/19')).toThrow(ValidationError);
+    expect(() => parseDate('19-04-2026')).toThrow(ValidationError);
+    expect(() => parseDate('2026-4-9')).toThrow(ValidationError);
+    expect(() => parseDate('not-a-date')).toThrow(ValidationError);
+    expect(() => parseDate('')).toThrow(ValidationError);
+  });
+
+  test('rejects out-of-range months/days', () => {
+    expect(() => parseDate('2026-13-01')).toThrow(ValidationError);
+    expect(() => parseDate('2026-00-01')).toThrow(ValidationError);
+    expect(() => parseDate('2026-01-00')).toThrow(ValidationError);
+    expect(() => parseDate('2026-01-32')).toThrow(ValidationError);
+  });
+});
+
+describe('formatDate', () => {
+  test('formats default yyyy-MM-dd in UTC', () => {
+    const d = new Date(Date.UTC(2026, 3, 19, 12, 0, 0));
+    expect(formatDate(d)).toBe('2026-04-19');
+  });
+
+  test('round-trips parseDate', () => {
+    const iso = '2026-04-19';
+    expect(formatDate(parseDate(iso))).toBe(iso);
+  });
+
+  test('respects custom format', () => {
+    const d = new Date(Date.UTC(2026, 3, 19, 0, 0, 0));
+    expect(formatDate(d, 'yyyy/MM/dd')).toMatch(/2026\/04\/19/);
+  });
+
+  test('throws on invalid Date', () => {
+    expect(() => formatDate(new Date('not-a-date'))).toThrow(ValidationError);
+  });
+});

--- a/tests/unit/format.test.ts
+++ b/tests/unit/format.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from 'bun:test';
+import { formatCsv, formatCurrency, formatJson, formatTable } from '../../src/lib/format';
+
+describe('formatCurrency', () => {
+  test('formats positive GBP', () => {
+    expect(formatCurrency(12.34, 'GBP')).toContain('12.34');
+    expect(formatCurrency(12.34, 'GBP')).toContain('£');
+  });
+
+  test('formats USD', () => {
+    expect(formatCurrency(99, 'USD')).toContain('99');
+    expect(formatCurrency(99, 'USD')).toContain('$');
+  });
+
+  test('formats EUR', () => {
+    expect(formatCurrency(7.5, 'EUR')).toContain('7.50');
+  });
+
+  test('formats negative amounts', () => {
+    const out = formatCurrency(-50, 'GBP');
+    // Should show the magnitude with a minus or parentheses; Intl chooses the
+    // locale-appropriate convention. Either way the digits are there.
+    expect(out).toContain('50');
+  });
+
+  test('falls back gracefully on unknown currency', () => {
+    const out = formatCurrency(10, 'XXX');
+    expect(out).toContain('10');
+  });
+
+  test('handles non-finite numbers without crashing', () => {
+    expect(formatCurrency(Number.NaN, 'GBP')).toBe('NaN');
+    expect(formatCurrency(Number.POSITIVE_INFINITY, 'GBP')).toBe('Infinity');
+  });
+});
+
+describe('formatCsv', () => {
+  test('returns empty string for empty input', () => {
+    expect(formatCsv([])).toBe('');
+  });
+
+  test('renders headers from first row keys', () => {
+    const out = formatCsv([{ a: 1, b: 'x' }]);
+    const [header, row] = out.split('\r\n');
+    expect(header).toBe('a,b');
+    expect(row).toBe('1,x');
+  });
+
+  test('quotes fields containing commas', () => {
+    const out = formatCsv([{ a: 'hello, world' }]);
+    expect(out).toContain('"hello, world"');
+  });
+
+  test('quotes fields containing quotes and doubles them', () => {
+    const out = formatCsv([{ a: 'she said "hi"' }]);
+    expect(out).toContain('"she said ""hi"""');
+  });
+
+  test('quotes fields containing newlines', () => {
+    const out = formatCsv([{ a: 'line1\nline2' }]);
+    expect(out).toContain('"line1\nline2"');
+  });
+
+  test('quotes fields containing carriage returns', () => {
+    const out = formatCsv([{ a: 'line1\r\nline2' }]);
+    expect(out.split('\r\n').length).toBeGreaterThan(2);
+    expect(out).toContain('"line1\r\nline2"');
+  });
+
+  test('renders null/undefined as empty fields', () => {
+    const out = formatCsv([{ a: null, b: undefined, c: 'ok' }]);
+    expect(out.split('\r\n')[1]).toBe(',,ok');
+  });
+
+  test('uses RFC 4180 CRLF line endings', () => {
+    const out = formatCsv([{ a: 1 }, { a: 2 }]);
+    expect(out).toContain('\r\n');
+  });
+
+  test('preserves key order across rows even when keys are missing', () => {
+    const out = formatCsv([
+      { a: 1, b: 2 },
+      { a: 3, c: 4 },
+    ]);
+    const lines = out.split('\r\n');
+    expect(lines[0]).toBe('a,b,c');
+    expect(lines[1]).toBe('1,2,');
+    expect(lines[2]).toBe('3,,4');
+  });
+});
+
+describe('formatJson', () => {
+  test('sorts keys recursively for determinism', () => {
+    const out = formatJson([{ b: 1, a: { d: 2, c: 3 } }]);
+    // Find the order in which keys appear in the serialized output.
+    const aIdx = out.indexOf('"a"');
+    const bIdx = out.indexOf('"b"');
+    const cIdx = out.indexOf('"c"');
+    const dIdx = out.indexOf('"d"');
+    expect(aIdx).toBeLessThan(bIdx);
+    expect(cIdx).toBeLessThan(dIdx);
+  });
+
+  test('preserves array order', () => {
+    const out = formatJson([3, 1, 2]);
+    expect(out).toBe('[\n  3,\n  1,\n  2\n]');
+  });
+
+  test('serializes empty array', () => {
+    expect(formatJson([])).toBe('[]');
+  });
+
+  test('handles nested objects and primitives', () => {
+    const out = formatJson({ x: [{ b: 2, a: 1 }] });
+    expect(JSON.parse(out)).toEqual({ x: [{ a: 1, b: 2 }] });
+  });
+});
+
+describe('formatTable', () => {
+  test('returns empty string on empty input', () => {
+    expect(formatTable([])).toBe('');
+  });
+
+  test('renders headers and rows', () => {
+    const out = formatTable([{ name: 'Alice', age: 30 }], { colors: false });
+    expect(out).toContain('name');
+    expect(out).toContain('Alice');
+    expect(out).toContain('30');
+  });
+
+  test('renders with custom head order', () => {
+    const out = formatTable([{ a: 1, b: 2 }], { head: ['b', 'a'], colors: false });
+    const bIdx = out.indexOf('b');
+    const aIdx = out.indexOf('a');
+    expect(bIdx).toBeLessThan(aIdx);
+  });
+});

--- a/tests/unit/list.test.ts
+++ b/tests/unit/list.test.ts
@@ -214,4 +214,60 @@ describe('listTransactions', () => {
     expect(() => listTransactions({ limit: 0 }, db)).toThrow();
     expect(() => listTransactions({ limit: -5 }, db)).toThrow();
   });
+
+  test('throws when --limit exceeds MAX_LIMIT instead of silently clamping', () => {
+    expect(() => listTransactions({ limit: 100_000 }, db)).toThrow(/exceeds the maximum/);
+  });
+
+  test('escapes LIKE metacharacters in merchant filter', () => {
+    // None of the seeded merchants contain `_` or `%`, so a query for
+    // `Tesco_X` (literal underscore) must match nothing rather than treating
+    // `_` as a single-character wildcard that would match `Tesco`.
+    const rows = listTransactions({ merchant: 'Tesco_X' }, db);
+    expect(rows.length).toBe(0);
+  });
+
+  test('escapes literal % in merchant filter', () => {
+    const rows = listTransactions({ merchant: '%' }, db);
+    expect(rows.length).toBe(0);
+  });
+
+  test('direction=incoming excludes zero-amount transactions', () => {
+    const localTmp = mkdtempSync(join(tmpdir(), 'ferret-list-zero-'));
+    const localPath = join(localTmp, 'test.db');
+    const localRaw = new Database(localPath, { create: true });
+    const localDb = drizzle(localRaw, { schema });
+    if (existsSync(migrationsFolder)) {
+      migrate(localDb, { migrationsFolder });
+    }
+    localRaw
+      .prepare(
+        `INSERT INTO connections (id, provider_id, provider_name, created_at, expires_at, status)
+         VALUES ('c', 'manual', 'B', ?, ?, 'active')`,
+      )
+      .run(sec(REF), sec(REF) + 86_400);
+    localRaw
+      .prepare(
+        `INSERT INTO accounts (id, connection_id, account_type, display_name, currency)
+         VALUES ('a', 'c', 'TRANSACTION', 'A', 'GBP')`,
+      )
+      .run();
+    const ins = localRaw.prepare(
+      `INSERT INTO transactions (id, account_id, timestamp, amount, currency, description,
+        merchant_name, transaction_type, category, category_source, created_at, updated_at)
+       VALUES (?, 'a', ?, ?, 'GBP', 'd', 'M', 'DEBIT', 'C', 'cache', ?, ?)`,
+    );
+    const ts = sec(REF);
+    ins.run('zero', ts, 0, ts, ts);
+    ins.run('pos', ts, 10, ts, ts);
+    ins.run('neg', ts, -10, ts, ts);
+
+    const incoming = listTransactions({ direction: 'incoming' }, localDb);
+    expect(incoming.map((r) => r.id)).toEqual(['pos']);
+    const outgoing = listTransactions({ direction: 'outgoing' }, localDb);
+    expect(outgoing.map((r) => r.id)).toEqual(['neg']);
+
+    localRaw.close();
+    rmSync(localTmp, { recursive: true, force: true });
+  });
 });

--- a/tests/unit/list.test.ts
+++ b/tests/unit/list.test.ts
@@ -1,0 +1,217 @@
+import { Database } from 'bun:sqlite';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { drizzle } from 'drizzle-orm/bun-sqlite';
+import { migrate } from 'drizzle-orm/bun-sqlite/migrator';
+import { listTransactions } from '../../src/db/queries/list';
+import * as schema from '../../src/db/schema';
+
+const tmp = mkdtempSync(join(tmpdir(), 'ferret-list-'));
+const dbPath = join(tmp, 'test.db');
+
+const here = dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = join(here, '..', '..', 'src', 'db', 'migrations');
+
+let raw: Database;
+let db: ReturnType<typeof drizzle<typeof schema>>;
+
+beforeAll(() => {
+  raw = new Database(dbPath, { create: true });
+  db = drizzle(raw, { schema });
+  if (existsSync(migrationsFolder)) {
+    migrate(db, { migrationsFolder });
+  }
+  seedFixtures(raw);
+});
+
+afterAll(() => {
+  raw.close();
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+const REF = new Date(Date.UTC(2026, 3, 19, 12, 0, 0)); // 2026-04-19T12:00:00Z
+
+function seedFixtures(raw: Database): void {
+  const conn = raw.prepare(
+    `INSERT INTO connections (id, provider_id, provider_name, created_at, expires_at, status)
+     VALUES (?, ?, ?, ?, ?, 'active')`,
+  );
+  conn.run('conn-1', 'manual', 'TestBank', sec(REF), sec(REF) + 86_400);
+
+  const acct = raw.prepare(
+    `INSERT INTO accounts (id, connection_id, account_type, display_name, currency)
+     VALUES (?, 'conn-1', 'TRANSACTION', ?, 'GBP')`,
+  );
+  acct.run('acct-current', 'Current Account');
+  acct.run('acct-savings', 'Savings');
+
+  const txn = raw.prepare(
+    `INSERT INTO transactions (id, account_id, timestamp, amount, currency, description,
+      merchant_name, transaction_type, category, category_source, created_at, updated_at)
+     VALUES (?, ?, ?, ?, 'GBP', ?, ?, ?, ?, 'cache', ?, ?)`,
+  );
+
+  // Helper: ts in seconds, days ago from REF.
+  const ago = (days: number): number => sec(REF) - days * 86_400;
+
+  // 10 fixture rows spanning various filters.
+  const rows: Array<[string, string, number, number, string, string, string, string]> = [
+    ['t1', 'acct-current', ago(1), -12.5, 'Tesco purchase', 'Tesco', 'DEBIT', 'Groceries'],
+    ['t2', 'acct-current', ago(3), -25.0, 'Pret a Manger', 'Pret a Manger', 'DEBIT', 'Eating Out'],
+    ['t3', 'acct-current', ago(5), -100.0, 'Uber', 'Uber', 'DEBIT', 'Ride Share'],
+    ['t4', 'acct-current', ago(7), 1500.0, 'Salary credit', 'EmployerCo', 'CREDIT', 'Salary'],
+    ['t5', 'acct-savings', ago(10), -75.5, 'Spotify', 'Spotify', 'DEBIT', 'Subscriptions'],
+    ['t6', 'acct-savings', ago(20), -8.0, 'Netflix', 'Netflix', 'DEBIT', 'Subscriptions'],
+    ['t7', 'acct-current', ago(40), -200.0, 'Shell fuel', 'Shell', 'DEBIT', 'Fuel'],
+    ['t8', 'acct-current', ago(50), -55.0, 'Tesco big shop', 'Tesco', 'DEBIT', 'Groceries'],
+    ['t9', 'acct-current', ago(2), 50.0, 'Refund Amazon', 'Amazon', 'CREDIT', 'General'],
+    ['t10', 'acct-current', ago(15), -33.33, 'Boots pharmacy', 'Boots', 'DEBIT', 'Pharmacy'],
+  ];
+
+  for (const r of rows) {
+    txn.run(r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[2], r[2]);
+  }
+}
+
+function sec(d: Date): number {
+  return Math.floor(d.getTime() / 1000);
+}
+
+describe('listTransactions', () => {
+  test('returns all rows by default sorted by timestamp desc', () => {
+    const rows = listTransactions({}, db);
+    expect(rows.length).toBe(10);
+    for (let i = 1; i < rows.length; i++) {
+      expect((rows[i - 1] as { timestamp: Date }).timestamp.getTime()).toBeGreaterThanOrEqual(
+        (rows[i] as { timestamp: Date }).timestamp.getTime(),
+      );
+    }
+  });
+
+  test('respects --limit', () => {
+    const rows = listTransactions({ limit: 3 }, db);
+    expect(rows.length).toBe(3);
+  });
+
+  test('default limit is 50', () => {
+    const rows = listTransactions({}, db);
+    expect(rows.length).toBeLessThanOrEqual(50);
+  });
+
+  test('filters by --since', () => {
+    const since = new Date(REF.getTime() - 7 * 86_400_000);
+    const rows = listTransactions({ since }, db);
+    expect(rows.every((r) => r.timestamp.getTime() >= since.getTime())).toBe(true);
+    expect(rows.map((r) => r.id).sort()).toEqual(['t1', 't2', 't3', 't4', 't9']);
+  });
+
+  test('filters by --until', () => {
+    const until = new Date(REF.getTime() - 30 * 86_400_000);
+    const rows = listTransactions({ until }, db);
+    expect(rows.every((r) => r.timestamp.getTime() <= until.getTime())).toBe(true);
+    expect(rows.map((r) => r.id).sort()).toEqual(['t7', 't8']);
+  });
+
+  test('filters by category', () => {
+    const rows = listTransactions({ category: 'Groceries' }, db);
+    expect(rows.map((r) => r.id).sort()).toEqual(['t1', 't8']);
+  });
+
+  test('filters by merchant substring (case-insensitive)', () => {
+    const rows = listTransactions({ merchant: 'tesco' }, db);
+    expect(rows.map((r) => r.id).sort()).toEqual(['t1', 't8']);
+  });
+
+  test('filters by accountId UUID', () => {
+    const rows = listTransactions({ accountId: 'acct-savings' }, db);
+    expect(rows.map((r) => r.id).sort()).toEqual(['t5', 't6']);
+  });
+
+  test('filters by account display name', () => {
+    const rows = listTransactions({ accountId: 'Savings' }, db);
+    expect(rows.map((r) => r.id).sort()).toEqual(['t5', 't6']);
+  });
+
+  test('filters by --min on absolute amount', () => {
+    const rows = listTransactions({ min: 100 }, db);
+    // |amount| >= 100 -> t3 (-100), t4 (1500), t7 (-200)
+    expect(rows.map((r) => r.id).sort()).toEqual(['t3', 't4', 't7']);
+  });
+
+  test('filters by --max on absolute amount', () => {
+    const rows = listTransactions({ max: 20 }, db);
+    // |amount| <= 20 -> t1 (-12.5), t6 (-8)
+    expect(rows.map((r) => r.id).sort()).toEqual(['t1', 't6']);
+  });
+
+  test('combines --min and --max', () => {
+    const rows = listTransactions({ min: 30, max: 80 }, db);
+    // |amount| in [30, 80]: t5 (-75.5), t8 (-55), t9 (+50), t10 (-33.33)
+    expect(rows.map((r) => r.id).sort()).toEqual(['t10', 't5', 't8', 't9']);
+  });
+
+  test('filters direction=incoming', () => {
+    const rows = listTransactions({ direction: 'incoming' }, db);
+    expect(rows.map((r) => r.id).sort()).toEqual(['t4', 't9']);
+    expect(rows.every((r) => r.amount >= 0)).toBe(true);
+  });
+
+  test('filters direction=outgoing', () => {
+    const rows = listTransactions({ direction: 'outgoing' }, db);
+    expect(rows.every((r) => r.amount <= 0)).toBe(true);
+    expect(rows.length).toBe(8);
+  });
+
+  test('sorts by amount asc', () => {
+    const rows = listTransactions({ sort: { field: 'amount', dir: 'asc' } }, db);
+    for (let i = 1; i < rows.length; i++) {
+      expect((rows[i - 1] as { amount: number }).amount).toBeLessThanOrEqual(
+        (rows[i] as { amount: number }).amount,
+      );
+    }
+  });
+
+  test('sorts by amount desc', () => {
+    const rows = listTransactions({ sort: { field: 'amount', dir: 'desc' } }, db);
+    expect(rows[0]?.id).toBe('t4'); // largest amount = +1500
+  });
+
+  test('sorts by merchant asc', () => {
+    const rows = listTransactions({ sort: { field: 'merchant', dir: 'asc' }, limit: 3 }, db);
+    expect(rows[0]?.merchantName).toBe('Amazon');
+  });
+
+  test('joins account display name', () => {
+    const rows = listTransactions({ category: 'Subscriptions' }, db);
+    expect(rows.every((r) => r.accountName === 'Savings')).toBe(true);
+  });
+
+  test('combines multiple filters', () => {
+    const since = new Date(REF.getTime() - 30 * 86_400_000);
+    const rows = listTransactions(
+      {
+        since,
+        direction: 'outgoing',
+        merchant: 'Tesco',
+      },
+      db,
+    );
+    expect(rows.map((r) => r.id).sort()).toEqual(['t1']);
+  });
+
+  test('throws on negative --min', () => {
+    expect(() => listTransactions({ min: -1 }, db)).toThrow();
+  });
+
+  test('throws on negative --max', () => {
+    expect(() => listTransactions({ max: -1 }, db)).toThrow();
+  });
+
+  test('throws on non-positive --limit', () => {
+    expect(() => listTransactions({ limit: 0 }, db)).toThrow();
+    expect(() => listTransactions({ limit: -5 }, db)).toThrow();
+  });
+});


### PR DESCRIPTION
Closes #4.

## Summary

Implements `ferret ls` end-to-end with every PRD §4.3 flag, plus the supporting `dates`/`format` libraries and a SQL-first query builder. All filtering happens in indexed SQL, never in JS — a 100k-row `--outgoing --limit 50` query runs in ~8ms locally (well under the 200ms PRD §11.1 target).

### What landed

- `src/lib/dates.ts` — `parseDuration` (`30d`, `2w`, `6m`, `2y`, ISO date), `parseDate` (strict `yyyy-MM-dd` with calendar validation), `formatDate`. UTC-safe; bad input throws `ValidationError`.
- `src/lib/format.ts` — `formatCurrency` (Intl + red on TTY for negatives), `formatTable` (cli-table3, ASCII when piped), `formatJson` (key-sorted for determinism), `formatCsv` (RFC 4180), `isTty()`.
- `src/db/queries/list.ts` — `listTransactions(filters, db?)` builder over drizzle. Joins `accounts` for the display name, hits the existing `txn_account_timestamp_idx` / `txn_category_idx` / `txn_merchant_idx` indexes, defaults to `timestamp DESC` and limit 50.
- `src/commands/ls.ts` — wires every flag (`--since`, `--until`, `--category`, `--merchant`, `--account`, `--min`, `--max`, `--incoming`, `--outgoing`, `--limit`, `--json`, `--csv`, `--sort`). Output priority: `--json` > `--csv` > TTY table > plain table. `--incoming`/`--outgoing` are mutually exclusive (`ValidationError` → exit 6).
- Tests: `tests/unit/dates.test.ts`, `tests/unit/format.test.ts`, `tests/unit/list.test.ts` (in-memory DB + fixtures).

## Test plan

- [x] `bun install`
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run check` — clean
- [x] `bun test` — 66 pass / 0 fail / 196 expects
- [x] `HOME=$(mktemp -d) bun run src/cli.ts init` — bootstraps `~/.ferret`
- [x] `HOME=$(mktemp -d) bash -c 'bun run src/cli.ts init && bun run scripts/dev-seed.ts && bun run src/cli.ts ls --since 30d --outgoing --limit 10'` — renders 10-row table
- [x] `bun run src/cli.ts ls --help` — shows all 13 flags
- [x] Perf: 100k seeded rows, `--outgoing --limit 50` returns in ~8ms

## Out of scope

- `--account` resolves by exact display name; fuzzy / partial-name routing is future work.
- TTY rendering uses unicode borders (cli-table3 default); themable styles can land in Phase 8 polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)