### PR TITLE
feat: Phase 7 — CSV import/export

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -1,15 +1,150 @@
 import { defineCommand } from 'citty';
-import { notImplemented } from '../lib/errors';
+import { and, eq, gte, lte } from 'drizzle-orm';
+import { getDb } from '../db/client';
+import { accounts, transactions } from '../db/schema';
+import { ValidationError } from '../lib/errors';
+
+type ExportFormat = 'csv' | 'json';
+
+interface ExportRow {
+  id: string;
+  account_id: string;
+  account_name: string | null;
+  source: string;
+  timestamp: string;
+  amount: number;
+  currency: string;
+  description: string;
+  merchant_name: string | null;
+  transaction_type: string | null;
+  category: string | null;
+  category_source: string | null;
+  provider_category: string | null;
+  running_balance: number | null;
+  is_pending: boolean;
+}
 
 export default defineCommand({
   meta: { name: 'export', description: 'Export transactions as CSV or JSON' },
   args: {
-    format: { type: 'string', description: 'csv | json' },
-    since: { type: 'string', description: 'Lower-bound date' },
-    until: { type: 'string', description: 'Upper-bound date' },
+    format: { type: 'string', description: 'csv | json (default csv)' },
+    since: { type: 'string', description: 'Lower-bound date (yyyy-MM-dd)' },
+    until: { type: 'string', description: 'Upper-bound date (yyyy-MM-dd)' },
     category: { type: 'string', description: 'Filter by category' },
   },
-  run() {
-    notImplemented('export', 4);
+  run({ args }) {
+    const formatArg = args.format ? String(args.format).toLowerCase() : 'csv';
+    if (formatArg !== 'csv' && formatArg !== 'json') {
+      throw new ValidationError(`Invalid format: ${formatArg}. Use 'csv' or 'json'.`);
+    }
+    const format: ExportFormat = formatArg as ExportFormat;
+
+    const since = args.since ? parseIsoDate(String(args.since), 'since') : undefined;
+    const until = args.until ? parseIsoDate(String(args.until), 'until', true) : undefined;
+    const category = args.category ? String(args.category) : undefined;
+
+    const { db } = getDb();
+
+    const conditions = [];
+    if (since) conditions.push(gte(transactions.timestamp, since));
+    if (until) conditions.push(lte(transactions.timestamp, until));
+    if (category) conditions.push(eq(transactions.category, category));
+
+    const baseQuery = db
+      .select({
+        id: transactions.id,
+        accountId: transactions.accountId,
+        accountName: accounts.displayName,
+        isManual: accounts.isManual,
+        timestamp: transactions.timestamp,
+        amount: transactions.amount,
+        currency: transactions.currency,
+        description: transactions.description,
+        merchantName: transactions.merchantName,
+        transactionType: transactions.transactionType,
+        category: transactions.category,
+        categorySource: transactions.categorySource,
+        providerCategory: transactions.providerCategory,
+        runningBalance: transactions.runningBalance,
+        isPending: transactions.isPending,
+      })
+      .from(transactions)
+      .leftJoin(accounts, eq(transactions.accountId, accounts.id));
+
+    const rows =
+      conditions.length > 0 ? baseQuery.where(and(...conditions)).all() : baseQuery.all();
+
+    const out: ExportRow[] = rows.map((r) => ({
+      id: r.id,
+      account_id: r.accountId,
+      account_name: r.accountName ?? null,
+      source: r.isManual ? 'csv' : 'sync',
+      timestamp: r.timestamp.toISOString(),
+      amount: r.amount,
+      currency: r.currency,
+      description: r.description,
+      merchant_name: r.merchantName ?? null,
+      transaction_type: r.transactionType ?? null,
+      category: r.category ?? null,
+      category_source: r.categorySource ?? null,
+      provider_category: r.providerCategory ?? null,
+      running_balance: r.runningBalance ?? null,
+      is_pending: Boolean(r.isPending),
+    }));
+
+    if (format === 'json') {
+      process.stdout.write(`${JSON.stringify(out, null, 2)}\n`);
+      return;
+    }
+
+    // CSV: streaming, write header + rows.
+    const headers: Array<keyof ExportRow> = [
+      'id',
+      'account_id',
+      'account_name',
+      'source',
+      'timestamp',
+      'amount',
+      'currency',
+      'description',
+      'merchant_name',
+      'transaction_type',
+      'category',
+      'category_source',
+      'provider_category',
+      'running_balance',
+      'is_pending',
+    ];
+    process.stdout.write(`${headers.join(',')}\n`);
+    for (const row of out) {
+      const cells = headers.map((h) => csvEscape(row[h]));
+      process.stdout.write(`${cells.join(',')}\n`);
+    }
   },
 });
+
+function parseIsoDate(s: string, label: string, endOfDay = false): Date {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+  if (!m) {
+    throw new ValidationError(`Invalid --${label} date: ${s}. Expected yyyy-MM-dd.`);
+  }
+  const y = Number.parseInt(m[1] as string, 10);
+  const mo = Number.parseInt(m[2] as string, 10);
+  const d = Number.parseInt(m[3] as string, 10);
+  const date = endOfDay
+    ? new Date(Date.UTC(y, mo - 1, d, 23, 59, 59, 999))
+    : new Date(Date.UTC(y, mo - 1, d));
+  if (Number.isNaN(date.getTime())) {
+    throw new ValidationError(`Invalid --${label} date: ${s}.`);
+  }
+  return date;
+}
+
+function csvEscape(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  const s = typeof value === 'string' ? value : String(value);
+  if (s.includes('"') || s.includes(',') || s.includes('\n') || s.includes('\r')) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,16 +1,62 @@
 import { defineCommand } from 'citty';
-import { notImplemented } from '../lib/errors';
+import { ValidationError } from '../lib/errors';
+import { BANK_FORMATS, type BankFormat, parseImport } from '../services/importers';
 
 export default defineCommand({
   meta: { name: 'import', description: 'Import transactions from CSV' },
   args: {
     file: { type: 'positional', description: 'Path to CSV file', required: true },
-    format: { type: 'string', description: 'Force format (lloyds, natwest, ...)' },
+    format: {
+      type: 'string',
+      description: `Force format (${BANK_FORMATS.join('|')})`,
+    },
     account: { type: 'string', description: 'Attach to specific account id' },
     'dry-run': { type: 'boolean', description: 'Preview without writing' },
-    'dedupe-strategy': { type: 'string', description: 'strict | loose' },
+    'dedupe-strategy': {
+      type: 'string',
+      description: 'strict | loose (default strict)',
+    },
   },
-  run() {
-    notImplemented('import', 8);
+  run({ args }) {
+    const file = String(args.file);
+    const formatArg = args.format ? String(args.format).toLowerCase() : undefined;
+    if (formatArg && !BANK_FORMATS.includes(formatArg as BankFormat)) {
+      throw new ValidationError(
+        `Unknown format: ${formatArg}. Supported: ${BANK_FORMATS.join(', ')}.`,
+      );
+    }
+    const dedupeArg = args['dedupe-strategy']
+      ? String(args['dedupe-strategy']).toLowerCase()
+      : undefined;
+    if (dedupeArg && dedupeArg !== 'strict' && dedupeArg !== 'loose') {
+      throw new ValidationError(`Invalid dedupe strategy: ${dedupeArg}. Use 'strict' or 'loose'.`);
+    }
+
+    const result = parseImport(file, {
+      format: formatArg as BankFormat | undefined,
+      account: args.account ? String(args.account) : undefined,
+      dryRun: Boolean(args['dry-run']),
+      dedupeStrategy: (dedupeArg ?? 'strict') as 'strict' | 'loose',
+    });
+
+    const banner = result.dryRun ? '[dry-run] ' : '';
+    process.stdout.write(
+      `${banner}format=${result.format} account=${result.accountId} parsed=${result.parsed} inserted=${result.inserted} duplicates=${result.duplicates}\n`,
+    );
+
+    if (result.dryRun && result.preview.length > 0) {
+      process.stdout.write('preview:\n');
+      for (const tx of result.preview) {
+        const iso = tx.date.toISOString().slice(0, 10);
+        const amt = formatAmount(tx.amount);
+        const cur = tx.currency ?? 'GBP';
+        process.stdout.write(`  ${iso}  ${amt} ${cur}  ${tx.description}\n`);
+      }
+    }
   },
 });
+
+function formatAmount(n: number): string {
+  const sign = n < 0 ? '-' : ' ';
+  return `${sign}${Math.abs(n).toFixed(2).padStart(9, ' ')}`;
+}

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,6 +1,11 @@
 import { defineCommand } from 'citty';
 import { ValidationError } from '../lib/errors';
-import { BANK_FORMATS, type BankFormat, parseImport } from '../services/importers';
+import {
+  BANK_FORMATS,
+  type BankFormat,
+  DEFAULT_PREVIEW_ROWS,
+  parseImport,
+} from '../services/importers';
 
 export default defineCommand({
   meta: { name: 'import', description: 'Import transactions from CSV' },
@@ -15,6 +20,10 @@ export default defineCommand({
     'dedupe-strategy': {
       type: 'string',
       description: 'strict | loose (default strict)',
+    },
+    'preview-rows': {
+      type: 'string',
+      description: `Number of rows shown under --dry-run (default ${DEFAULT_PREVIEW_ROWS})`,
     },
   },
   run({ args }) {
@@ -32,11 +41,23 @@ export default defineCommand({
       throw new ValidationError(`Invalid dedupe strategy: ${dedupeArg}. Use 'strict' or 'loose'.`);
     }
 
+    let previewRows: number | undefined;
+    if (args['preview-rows'] !== undefined) {
+      const n = Number.parseInt(String(args['preview-rows']), 10);
+      if (!Number.isFinite(n) || n < 0) {
+        throw new ValidationError(
+          `Invalid --preview-rows: ${String(args['preview-rows'])}. Expected a non-negative integer.`,
+        );
+      }
+      previewRows = n;
+    }
+
     const result = parseImport(file, {
       format: formatArg as BankFormat | undefined,
       account: args.account ? String(args.account) : undefined,
       dryRun: Boolean(args['dry-run']),
       dedupeStrategy: (dedupeArg ?? 'strict') as 'strict' | 'loose',
+      previewRows,
     });
 
     const banner = result.dryRun ? '[dry-run] ' : '';

--- a/src/services/importers/barclays.ts
+++ b/src/services/importers/barclays.ts
@@ -1,0 +1,81 @@
+// Barclays CSV parser.
+//
+// TODO: validate against real export.
+//
+// Best-effort header (Barclays online banking statement download):
+//   Number,Date,Account,Amount,Subcategory,Memo
+//
+// Date format: dd/MM/yyyy.
+// Sign convention: Barclays uses a single signed Amount column where debits
+// are negative. Pass through.
+// Description is sourced from the Memo column.
+
+import { ValidationError } from '../../lib/errors';
+import { type ParsedTransaction, parseCsv } from './index';
+
+export function parseBarclays(raw: string): ParsedTransaction[] {
+  const rows = parseCsv(raw);
+  if (rows.length === 0) return [];
+
+  let headerIdx = -1;
+  let headers: string[] = [];
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row) continue;
+    const lower = row.map((c) => c.trim().toLowerCase());
+    if (lower.includes('memo') && lower.includes('amount') && lower.includes('date')) {
+      headerIdx = i;
+      headers = lower;
+      break;
+    }
+  }
+  if (headerIdx === -1) {
+    throw new ValidationError('Barclays parser: header row not found');
+  }
+
+  const idx = {
+    date: headers.indexOf('date'),
+    amount: headers.indexOf('amount'),
+    memo: headers.indexOf('memo'),
+    subcategory: headers.indexOf('subcategory'),
+  };
+
+  const out: ParsedTransaction[] = [];
+  for (let i = headerIdx + 1; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row || row.every((c) => c.trim() === '')) continue;
+
+    const dateStr = (row[idx.date] ?? '').trim();
+    const amountStr = (row[idx.amount] ?? '').trim();
+    const memo = (row[idx.memo] ?? '').trim();
+    const sub = idx.subcategory !== -1 ? (row[idx.subcategory] ?? '').trim() : '';
+    if (!dateStr) continue;
+
+    const description = memo || sub;
+    out.push({
+      date: parseUkDate(dateStr),
+      amount: parseFloatSafe(amountStr),
+      description,
+      currency: 'GBP',
+    });
+  }
+  return out;
+}
+
+function parseUkDate(s: string): Date {
+  const m = /^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/.exec(s);
+  if (!m) throw new ValidationError(`Barclays parser: invalid date '${s}'`);
+  const day = Number.parseInt(m[1] as string, 10);
+  const month = Number.parseInt(m[2] as string, 10);
+  let year = Number.parseInt(m[3] as string, 10);
+  if (year < 100) year += 2000;
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function parseFloatSafe(s: string): number {
+  if (!s) return 0;
+  const cleaned = s.replace(/[£,]/g, '').trim();
+  if (!cleaned) return 0;
+  const n = Number.parseFloat(cleaned);
+  return Number.isFinite(n) ? n : 0;
+}

--- a/src/services/importers/barclays.ts
+++ b/src/services/importers/barclays.ts
@@ -1,6 +1,6 @@
 // Barclays CSV parser.
 //
-// TODO: validate against real export.
+// TODO(#26): validate against real export.
 //
 // Best-effort header (Barclays online banking statement download):
 //   Number,Date,Account,Amount,Subcategory,Memo
@@ -12,6 +12,12 @@
 
 import { ValidationError } from '../../lib/errors';
 import { type ParsedTransaction, parseCsv } from './index';
+import { parseFloatSafe, parseUkDate } from './uk-date';
+
+const PARSER_NAME = 'Barclays';
+
+/** Synthetic placeholder when both memo and subcategory are empty. */
+export const EMPTY_DESCRIPTION = '(no description)';
 
 export function parseBarclays(raw: string): ParsedTransaction[] {
   const rows = parseCsv(raw);
@@ -30,7 +36,7 @@ export function parseBarclays(raw: string): ParsedTransaction[] {
     }
   }
   if (headerIdx === -1) {
-    throw new ValidationError('Barclays parser: header row not found');
+    throw new ValidationError(`${PARSER_NAME} parser: header row not found`);
   }
 
   const idx = {
@@ -51,31 +57,16 @@ export function parseBarclays(raw: string): ParsedTransaction[] {
     const sub = idx.subcategory !== -1 ? (row[idx.subcategory] ?? '').trim() : '';
     if (!dateStr) continue;
 
-    const description = memo || sub;
+    // Synthetic marker keeps dedupe keys distinct for rows where both memo and
+    // subcategory are empty. Without this, all such rows on the same date for
+    // the same amount would collapse into one hash.
+    const description = memo || sub || EMPTY_DESCRIPTION;
     out.push({
-      date: parseUkDate(dateStr),
-      amount: parseFloatSafe(amountStr),
+      date: parseUkDate(dateStr, PARSER_NAME),
+      amount: parseFloatSafe(amountStr, PARSER_NAME, i + 1),
       description,
       currency: 'GBP',
     });
   }
   return out;
-}
-
-function parseUkDate(s: string): Date {
-  const m = /^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/.exec(s);
-  if (!m) throw new ValidationError(`Barclays parser: invalid date '${s}'`);
-  const day = Number.parseInt(m[1] as string, 10);
-  const month = Number.parseInt(m[2] as string, 10);
-  let year = Number.parseInt(m[3] as string, 10);
-  if (year < 100) year += 2000;
-  return new Date(Date.UTC(year, month - 1, day));
-}
-
-function parseFloatSafe(s: string): number {
-  if (!s) return 0;
-  const cleaned = s.replace(/[£,]/g, '').trim();
-  if (!cleaned) return 0;
-  const n = Number.parseFloat(cleaned);
-  return Number.isFinite(n) ? n : 0;
 }

--- a/src/services/importers/dedupe.ts
+++ b/src/services/importers/dedupe.ts
@@ -9,9 +9,16 @@
 //
 // Performance note: the orchestrator narrows the candidate set to a date
 // window before calling these helpers, so `existing` here is already small
-// (typically a few dozen rows, not the whole account history). The strict
-// path additionally short-circuits via id-equality and a (date,amount,desc)
-// hash index built once per import — see `buildStrictIndex` below.
+// (typically a few dozen rows, not the whole account history). Both modes
+// additionally use a pre-built hash index to avoid the O(parsed × window)
+// inner scan:
+//   - strict: key = (date, amount, normalized desc) — exact O(1) lookup, see
+//     `buildStrictIndex` / `isDuplicateStrict`.
+//   - loose:  key = (date, amount) — bucket lookup with the (small) bucket
+//     scanned for substring/Levenshtein, see `buildLooseBuckets` /
+//     `isDuplicateLoose`. Average case O(parsed + window); worst case still
+//     O(parsed × window) but only when every existing row shares the same
+//     (date, amount), which is vanishingly unlikely in real bank data.
 
 export interface DedupeCandidate {
   id: string;
@@ -91,6 +98,69 @@ export function isDuplicate(
 export function isDuplicateStrict(candidate: DedupeCandidate, index: StrictDedupeIndex): boolean {
   if (index.ids.has(candidate.id)) return true;
   return index.keys.has(strictKey(candidate.date, candidate.amount, candidate.description));
+}
+
+/**
+ * Bucket key for loose-mode dedupe: (yyyy-MM-dd, amount-rounded). Description
+ * is intentionally excluded — loose mode allows substring / small-edit
+ * differences in description, so we hash on the parts that must match
+ * exactly and scan within the (typically tiny) bucket.
+ */
+function looseBucketKey(date: Date, amount: number): string {
+  const iso = date.toISOString().slice(0, 10);
+  const cents = Math.round(amount * 100);
+  return `${iso}|${cents}`;
+}
+
+/**
+ * Pre-built bucket index for loose-mode dedupe. Build once per import batch.
+ *
+ * Average case: O(parsed + window) total across all rows, since each candidate
+ * looks up a bucket in O(1) and most buckets contain 0–3 entries. The id set
+ * powers the same id-equality short-circuit as the strict path.
+ */
+export interface LooseDedupeIndex {
+  ids: Set<string>;
+  buckets: Map<string, ExistingTxn[]>;
+}
+
+// O(parsed + window) average: O(window) to build buckets once, O(1) lookup +
+// O(bucket size) scan per parsed row. See module header for full reasoning.
+export function buildLooseBuckets(existing: readonly ExistingTxn[]): LooseDedupeIndex {
+  const ids = new Set<string>();
+  const buckets = new Map<string, ExistingTxn[]>();
+  for (const ex of existing) {
+    ids.add(ex.id);
+    // Loose mode tolerates ±1 day, so index the row under its own day AND the
+    // adjacent days. This keeps lookup a single O(1) hit per candidate.
+    const dayMs = ex.date.getTime();
+    for (const offset of [-ONE_DAY_MS, 0, ONE_DAY_MS] as const) {
+      const key = looseBucketKey(new Date(dayMs + offset), ex.amount);
+      let bucket = buckets.get(key);
+      if (!bucket) {
+        bucket = [];
+        buckets.set(key, bucket);
+      }
+      bucket.push(ex);
+    }
+  }
+  return { ids, buckets };
+}
+
+/**
+ * Loose-mode dedupe via pre-built bucket index. Average O(1) per call (plus
+ * a small constant for the in-bucket fuzzy check).
+ */
+export function isDuplicateLoose(candidate: DedupeCandidate, index: LooseDedupeIndex): boolean {
+  if (index.ids.has(candidate.id)) return true;
+  const bucket = index.buckets.get(looseBucketKey(candidate.date, candidate.amount));
+  if (!bucket) return false;
+  // Bucket already filtered to (same day ± 1, same rounded amount). The
+  // remaining work is the description fuzzy match, scoped to a handful of rows.
+  for (const ex of bucket) {
+    if (looseEquals(ex, candidate)) return true;
+  }
+  return false;
 }
 
 function strictEquals(a: ExistingTxn, b: DedupeCandidate): boolean {

--- a/src/services/importers/dedupe.ts
+++ b/src/services/importers/dedupe.ts
@@ -6,6 +6,12 @@
 //   - 'strict' requires exact match across all 3.
 //   - 'loose' does fuzzy match on description (Levenshtein distance < 3 or
 //     normalized substring).
+//
+// Performance note: the orchestrator narrows the candidate set to a date
+// window before calling these helpers, so `existing` here is already small
+// (typically a few dozen rows, not the whole account history). The strict
+// path additionally short-circuits via id-equality and a (date,amount,desc)
+// hash index built once per import — see `buildStrictIndex` below.
 
 export interface DedupeCandidate {
   id: string;
@@ -24,8 +30,44 @@ export interface ExistingTxn {
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
+ * Hash key for strict-mode dedupe: (yyyy-MM-dd, amount-rounded, normalized desc).
+ *
+ * We round to cents to avoid floating-point jitter producing distinct keys for
+ * the same logical amount (e.g. 12.5 vs 12.500000000000002).
+ */
+function strictKey(date: Date, amount: number, description: string): string {
+  const iso = date.toISOString().slice(0, 10);
+  const cents = Math.round(amount * 100);
+  return `${iso}|${cents}|${normalize(description)}`;
+}
+
+/**
+ * Pre-built index for strict-mode dedupe. Build once per import batch, query
+ * O(1) per candidate row. Also exposes the raw id set for the id-equality
+ * short-circuit (covers re-importing the exact same file).
+ */
+export interface StrictDedupeIndex {
+  ids: Set<string>;
+  keys: Set<string>;
+}
+
+export function buildStrictIndex(existing: readonly ExistingTxn[]): StrictDedupeIndex {
+  const ids = new Set<string>();
+  const keys = new Set<string>();
+  for (const ex of existing) {
+    ids.add(ex.id);
+    keys.add(strictKey(ex.date, ex.amount, ex.description));
+  }
+  return { ids, keys };
+}
+
+/**
  * Returns true when `candidate` matches some entry in `existing` per the chosen
  * strategy. Used to skip inserting a CSV row that already lives in the DB.
+ *
+ * `existing` should already be narrowed to a date window by the caller (the
+ * orchestrator does this for each import batch). For strict-mode hot loops,
+ * prefer `isDuplicateStrict` with a pre-built index.
  */
 export function isDuplicate(
   candidate: DedupeCandidate,
@@ -41,6 +83,14 @@ export function isDuplicate(
     return existing.some((ex) => strictEquals(ex, candidate));
   }
   return existing.some((ex) => looseEquals(ex, candidate));
+}
+
+/**
+ * Strict-mode dedupe via pre-built hash index. O(1) per call.
+ */
+export function isDuplicateStrict(candidate: DedupeCandidate, index: StrictDedupeIndex): boolean {
+  if (index.ids.has(candidate.id)) return true;
+  return index.keys.has(strictKey(candidate.date, candidate.amount, candidate.description));
 }
 
 function strictEquals(a: ExistingTxn, b: DedupeCandidate): boolean {

--- a/src/services/importers/dedupe.ts
+++ b/src/services/importers/dedupe.ts
@@ -1,0 +1,114 @@
+// Dedupe logic for CSV imports.
+//
+// PRD §4.7:
+// - For txns with provider_transaction_id, dedupe by id (won't apply for CSV).
+// - For CSV: hash of (date, amount, description) -> check transactions.id.
+//   - 'strict' requires exact match across all 3.
+//   - 'loose' does fuzzy match on description (Levenshtein distance < 3 or
+//     normalized substring).
+
+export interface DedupeCandidate {
+  id: string;
+  date: Date;
+  amount: number;
+  description: string;
+}
+
+export interface ExistingTxn {
+  id: string;
+  date: Date;
+  amount: number;
+  description: string;
+}
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Returns true when `candidate` matches some entry in `existing` per the chosen
+ * strategy. Used to skip inserting a CSV row that already lives in the DB.
+ */
+export function isDuplicate(
+  candidate: DedupeCandidate,
+  existing: readonly ExistingTxn[],
+  strategy: 'strict' | 'loose',
+): boolean {
+  // Fast id-equality short-circuit (covers re-imports of the exact same file).
+  for (const ex of existing) {
+    if (ex.id === candidate.id) return true;
+  }
+
+  if (strategy === 'strict') {
+    return existing.some((ex) => strictEquals(ex, candidate));
+  }
+  return existing.some((ex) => looseEquals(ex, candidate));
+}
+
+function strictEquals(a: ExistingTxn, b: DedupeCandidate): boolean {
+  if (!sameDay(a.date, b.date)) return false;
+  if (Math.abs(a.amount - b.amount) > 0.005) return false;
+  return normalize(a.description) === normalize(b.description);
+}
+
+function looseEquals(a: ExistingTxn, b: DedupeCandidate): boolean {
+  // Loose: same day (or adjacent day), amount equal to within 0.01, and
+  // description either substring-matches normalized form OR Levenshtein < 3.
+  if (Math.abs(a.date.getTime() - b.date.getTime()) > ONE_DAY_MS) return false;
+  if (Math.abs(a.amount - b.amount) > 0.01) return false;
+
+  const aDesc = normalize(a.description);
+  const bDesc = normalize(b.description);
+  if (!aDesc || !bDesc) return aDesc === bDesc;
+  if (aDesc === bDesc) return true;
+  if (aDesc.includes(bDesc) || bDesc.includes(aDesc)) return true;
+  return levenshtein(aDesc, bDesc) < 3;
+}
+
+function sameDay(a: Date, b: Date): boolean {
+  return (
+    a.getUTCFullYear() === b.getUTCFullYear() &&
+    a.getUTCMonth() === b.getUTCMonth() &&
+    a.getUTCDate() === b.getUTCDate()
+  );
+}
+
+function normalize(s: string): string {
+  return s.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Iterative two-row Levenshtein distance. O(n*m) time, O(min(n,m)) space.
+ */
+export function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  // Make `short` the shorter to keep memory low.
+  const short = a.length > b.length ? b : a;
+  const long = a.length > b.length ? a : b;
+
+  const m = short.length;
+  const n = long.length;
+  let prev = new Array<number>(m + 1);
+  let curr = new Array<number>(m + 1);
+  for (let i = 0; i <= m; i++) prev[i] = i;
+
+  for (let j = 1; j <= n; j++) {
+    curr[0] = j;
+    const bj = long.charCodeAt(j - 1);
+    for (let i = 1; i <= m; i++) {
+      const cost = short.charCodeAt(i - 1) === bj ? 0 : 1;
+      const del = (prev[i] as number) + 1;
+      const ins = (curr[i - 1] as number) + 1;
+      const sub = (prev[i - 1] as number) + cost;
+      let min = del;
+      if (ins < min) min = ins;
+      if (sub < min) min = sub;
+      curr[i] = min;
+    }
+    const tmp = prev;
+    prev = curr;
+    curr = tmp;
+  }
+  return prev[m] as number;
+}

--- a/src/services/importers/hsbc.ts
+++ b/src/services/importers/hsbc.ts
@@ -1,0 +1,78 @@
+// HSBC CSV parser.
+//
+// TODO: validate against real export.
+//
+// Best-effort header (HSBC UK personal banking statement download):
+//   Date,Description,Amount,Balance
+// Some exports also include a "Type" column. We tolerate both.
+//
+// Date format: dd/MM/yyyy.
+// Sign convention: HSBC uses a single signed Amount column where debits are
+// negative. Pass through.
+
+import { ValidationError } from '../../lib/errors';
+import { type ParsedTransaction, parseCsv } from './index';
+
+export function parseHsbc(raw: string): ParsedTransaction[] {
+  const rows = parseCsv(raw);
+  if (rows.length === 0) return [];
+
+  let headerIdx = -1;
+  let headers: string[] = [];
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row) continue;
+    const lower = row.map((c) => c.trim().toLowerCase());
+    if (lower.includes('date') && lower.includes('description') && lower.includes('amount')) {
+      headerIdx = i;
+      headers = lower;
+      break;
+    }
+  }
+  if (headerIdx === -1) {
+    throw new ValidationError('HSBC parser: header row not found');
+  }
+
+  const idx = {
+    date: headers.indexOf('date'),
+    description: headers.indexOf('description'),
+    amount: headers.indexOf('amount'),
+  };
+
+  const out: ParsedTransaction[] = [];
+  for (let i = headerIdx + 1; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row || row.every((c) => c.trim() === '')) continue;
+
+    const dateStr = (row[idx.date] ?? '').trim();
+    const description = (row[idx.description] ?? '').trim();
+    const amountStr = (row[idx.amount] ?? '').trim();
+    if (!dateStr) continue;
+
+    out.push({
+      date: parseUkDate(dateStr),
+      amount: parseFloatSafe(amountStr),
+      description,
+      currency: 'GBP',
+    });
+  }
+  return out;
+}
+
+function parseUkDate(s: string): Date {
+  const m = /^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/.exec(s);
+  if (!m) throw new ValidationError(`HSBC parser: invalid date '${s}'`);
+  const day = Number.parseInt(m[1] as string, 10);
+  const month = Number.parseInt(m[2] as string, 10);
+  let year = Number.parseInt(m[3] as string, 10);
+  if (year < 100) year += 2000;
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function parseFloatSafe(s: string): number {
+  if (!s) return 0;
+  const cleaned = s.replace(/[£,]/g, '').trim();
+  if (!cleaned) return 0;
+  const n = Number.parseFloat(cleaned);
+  return Number.isFinite(n) ? n : 0;
+}

--- a/src/services/importers/hsbc.ts
+++ b/src/services/importers/hsbc.ts
@@ -1,6 +1,6 @@
 // HSBC CSV parser.
 //
-// TODO: validate against real export.
+// TODO(#27): validate against real export.
 //
 // Best-effort header (HSBC UK personal banking statement download):
 //   Date,Description,Amount,Balance
@@ -12,6 +12,9 @@
 
 import { ValidationError } from '../../lib/errors';
 import { type ParsedTransaction, parseCsv } from './index';
+import { parseFloatSafe, parseUkDate } from './uk-date';
+
+const PARSER_NAME = 'HSBC';
 
 export function parseHsbc(raw: string): ParsedTransaction[] {
   const rows = parseCsv(raw);
@@ -30,7 +33,7 @@ export function parseHsbc(raw: string): ParsedTransaction[] {
     }
   }
   if (headerIdx === -1) {
-    throw new ValidationError('HSBC parser: header row not found');
+    throw new ValidationError(`${PARSER_NAME} parser: header row not found`);
   }
 
   const idx = {
@@ -50,29 +53,11 @@ export function parseHsbc(raw: string): ParsedTransaction[] {
     if (!dateStr) continue;
 
     out.push({
-      date: parseUkDate(dateStr),
-      amount: parseFloatSafe(amountStr),
+      date: parseUkDate(dateStr, PARSER_NAME),
+      amount: parseFloatSafe(amountStr, PARSER_NAME, i + 1),
       description,
       currency: 'GBP',
     });
   }
   return out;
-}
-
-function parseUkDate(s: string): Date {
-  const m = /^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/.exec(s);
-  if (!m) throw new ValidationError(`HSBC parser: invalid date '${s}'`);
-  const day = Number.parseInt(m[1] as string, 10);
-  const month = Number.parseInt(m[2] as string, 10);
-  let year = Number.parseInt(m[3] as string, 10);
-  if (year < 100) year += 2000;
-  return new Date(Date.UTC(year, month - 1, day));
-}
-
-function parseFloatSafe(s: string): number {
-  if (!s) return 0;
-  const cleaned = s.replace(/[£,]/g, '').trim();
-  if (!cleaned) return 0;
-  const n = Number.parseFloat(cleaned);
-  return Number.isFinite(n) ? n : 0;
 }

--- a/src/services/importers/index.ts
+++ b/src/services/importers/index.ts
@@ -14,7 +14,7 @@ import { accounts, transactions } from '../../db/schema';
 import * as schema from '../../db/schema';
 import { DataIntegrityError, ValidationError } from '../../lib/errors';
 import { parseBarclays } from './barclays';
-import { buildStrictIndex, isDuplicate, isDuplicateStrict } from './dedupe';
+import { buildLooseBuckets, buildStrictIndex, isDuplicateLoose, isDuplicateStrict } from './dedupe';
 import { parseHsbc } from './hsbc';
 import { parseLloyds } from './lloyds';
 import { parseNatwest } from './natwest';
@@ -382,10 +382,15 @@ export function runImport(
     }));
   }
 
-  // Strict mode uses an O(1) hash lookup over the narrowed window. Loose mode
-  // still iterates so it can apply substring / Levenshtein matching, but only
-  // over the narrowed window (typically a few dozen rows, not the full table).
+  // Both modes pre-build a hash index over the narrowed window so the per-row
+  // lookup is O(1) on average:
+  //   - strict: keyed on (date, amount, normalized desc) — exact match.
+  //   - loose:  keyed on (date, amount) — bucket scanned for substring /
+  //     Levenshtein. Buckets are tiny in real bank data (date + exact penny
+  //     match almost always yields 0 or 1 row), so the scan is effectively
+  //     constant. See `dedupe.ts` for the complexity analysis.
   const strictIndex = dedupeStrategy === 'strict' ? buildStrictIndex(existingForDedupe) : null;
+  const looseIndex = dedupeStrategy === 'loose' ? buildLooseBuckets(existingForDedupe) : null;
 
   let inserted = 0;
   let duplicates = 0;
@@ -403,7 +408,8 @@ export function runImport(
     const candidate = { id, date: tx.date, amount: tx.amount, description: tx.description };
     const isDup = strictIndex
       ? isDuplicateStrict(candidate, strictIndex)
-      : isDuplicate(candidate, existingForDedupe, dedupeStrategy);
+      : // biome-ignore lint/style/noNonNullAssertion: looseIndex is set whenever strictIndex isn't.
+        isDuplicateLoose(candidate, looseIndex!);
     if (isDup) {
       duplicates += 1;
       continue;

--- a/src/services/importers/index.ts
+++ b/src/services/importers/index.ts
@@ -7,14 +7,14 @@
 
 import { createHash } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
-import { eq } from 'drizzle-orm';
+import { and, eq, gte, lte } from 'drizzle-orm';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import { getDb } from '../../db/client';
 import { accounts, transactions } from '../../db/schema';
 import * as schema from '../../db/schema';
 import { DataIntegrityError, ValidationError } from '../../lib/errors';
 import { parseBarclays } from './barclays';
-import { isDuplicate } from './dedupe';
+import { buildStrictIndex, isDuplicate, isDuplicateStrict } from './dedupe';
 import { parseHsbc } from './hsbc';
 import { parseLloyds } from './lloyds';
 import { parseNatwest } from './natwest';
@@ -44,7 +44,22 @@ export interface ImportOptions {
   account?: string;
   dryRun?: boolean;
   dedupeStrategy?: 'strict' | 'loose';
+  /** Cap on the number of preview rows returned in dry-run output. Default 10. */
+  previewRows?: number;
 }
+
+/** Default cap for dry-run preview rows when previewRows is not set. */
+export const DEFAULT_PREVIEW_ROWS = 10;
+
+/** Days of fuzz on either side of the import batch's date range when narrowing
+ *  the dedupe candidate set. Loose mode tolerates ±1 day; we double it for
+ *  safety and to absorb any out-of-order rows the bank may emit. */
+const DEDUPE_DATE_FUZZ_DAYS = 7;
+const DEDUPE_DATE_FUZZ_MS = DEDUPE_DATE_FUZZ_DAYS * 24 * 60 * 60 * 1000;
+
+/** Multi-row INSERT chunk size. SQLite tolerates much larger but Drizzle's
+ *  parameter binding gets sluggish past a few hundred rows per statement. */
+const INSERT_CHUNK_SIZE = 500;
 
 export interface ImportResult {
   format: BankFormat;
@@ -164,11 +179,21 @@ export function detectFormat(headerLine: string): BankFormat | null {
   }
 
   // NatWest: "Date, Type, Description, Value, Balance, Account Name, Account Number"
+  // We require 'description' AND 'value' AND 'account number' AND a literal
+  // 'type' column header. The prior signature only required date + account
+  // name/number + value, which was loose enough to match generic ledger
+  // exports that happened to share those column names.
+  const hasTypeCol =
+    normalized.includes(',type,') ||
+    normalized.startsWith('type,') ||
+    normalized.endsWith(',type') ||
+    normalized.includes(', type,');
   if (
     normalized.includes('date') &&
-    normalized.includes('account name') &&
+    normalized.includes('description') &&
+    normalized.includes('value') &&
     normalized.includes('account number') &&
-    normalized.includes('value')
+    hasTypeCol
   ) {
     return 'natwest';
   }
@@ -301,30 +326,8 @@ export function runImport(
     ? (opts.account ?? 'manual:dry-run')
     : ensureAccount(db, opts.account, format);
 
-  // Dedupe within DB.
-  const existing = db
-    .select({
-      id: transactions.id,
-      timestamp: transactions.timestamp,
-      amount: transactions.amount,
-      description: transactions.description,
-    })
-    .from(transactions)
-    .where(eq(transactions.accountId, accountId))
-    .all();
-
-  const existingForDedupe = existing.map((row) => ({
-    id: row.id,
-    date: row.timestamp,
-    amount: row.amount,
-    description: row.description,
-  }));
-
-  let inserted = 0;
-  let duplicates = 0;
-  const toInsert: Array<typeof transactions.$inferInsert> = [];
-  const seenIds = new Set<string>();
-
+  // Validate every parsed row up front so the date-window narrowing below
+  // doesn't see NaN timestamps.
   for (const tx of parsed) {
     if (Number.isNaN(tx.date.getTime())) {
       throw new DataIntegrityError(
@@ -336,6 +339,60 @@ export function runImport(
         `Parsed transaction has non-finite amount: ${tx.description} / ${String(tx.amount)}`,
       );
     }
+  }
+
+  // Narrow the dedupe candidate set to the import batch's date range ±
+  // DEDUPE_DATE_FUZZ_DAYS. Without this we previously fetched every
+  // transaction for the account and compared each parsed row against all of
+  // them — O(parsed × existing). Now both modes get a bounded window, and
+  // strict mode further uses an O(1) hash index.
+  let existingForDedupe: Array<{ id: string; date: Date; amount: number; description: string }> =
+    [];
+  if (parsed.length > 0) {
+    let minTs = Number.POSITIVE_INFINITY;
+    let maxTs = Number.NEGATIVE_INFINITY;
+    for (const tx of parsed) {
+      const t = tx.date.getTime();
+      if (t < minTs) minTs = t;
+      if (t > maxTs) maxTs = t;
+    }
+    const fromDate = new Date(minTs - DEDUPE_DATE_FUZZ_MS);
+    const toDate = new Date(maxTs + DEDUPE_DATE_FUZZ_MS);
+    const existing = db
+      .select({
+        id: transactions.id,
+        timestamp: transactions.timestamp,
+        amount: transactions.amount,
+        description: transactions.description,
+      })
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.accountId, accountId),
+          gte(transactions.timestamp, fromDate),
+          lte(transactions.timestamp, toDate),
+        ),
+      )
+      .all();
+    existingForDedupe = existing.map((row) => ({
+      id: row.id,
+      date: row.timestamp,
+      amount: row.amount,
+      description: row.description,
+    }));
+  }
+
+  // Strict mode uses an O(1) hash lookup over the narrowed window. Loose mode
+  // still iterates so it can apply substring / Levenshtein matching, but only
+  // over the narrowed window (typically a few dozen rows, not the full table).
+  const strictIndex = dedupeStrategy === 'strict' ? buildStrictIndex(existingForDedupe) : null;
+
+  let inserted = 0;
+  let duplicates = 0;
+  const toInsert: Array<typeof transactions.$inferInsert> = [];
+  const seenIds = new Set<string>();
+
+  for (const tx of parsed) {
     const id = transactionHashId(accountId, tx.date, tx.amount, tx.description);
     if (seenIds.has(id)) {
       duplicates += 1;
@@ -343,13 +400,11 @@ export function runImport(
     }
     seenIds.add(id);
 
-    if (
-      isDuplicate(
-        { id, date: tx.date, amount: tx.amount, description: tx.description },
-        existingForDedupe,
-        dedupeStrategy,
-      )
-    ) {
+    const candidate = { id, date: tx.date, amount: tx.amount, description: tx.description };
+    const isDup = strictIndex
+      ? isDuplicateStrict(candidate, strictIndex)
+      : isDuplicate(candidate, existingForDedupe, dedupeStrategy);
+    if (isDup) {
       duplicates += 1;
       continue;
     }
@@ -371,20 +426,24 @@ export function runImport(
   }
 
   if (!opts.dryRun && toInsert.length > 0) {
+    // Batch into chunked multi-row INSERTs. SQLite executes one statement per
+    // chunk (vs one per row), which is materially faster on large imports.
     db.transaction((tx) => {
-      for (const row of toInsert) {
-        tx.insert(transactions).values(row).run();
+      for (let i = 0; i < toInsert.length; i += INSERT_CHUNK_SIZE) {
+        const chunk = toInsert.slice(i, i + INSERT_CHUNK_SIZE);
+        tx.insert(transactions).values(chunk).run();
       }
     });
   }
 
+  const previewCap = Math.max(0, opts.previewRows ?? DEFAULT_PREVIEW_ROWS);
   return {
     format,
     accountId,
     parsed: parsed.length,
     inserted: opts.dryRun ? 0 : inserted,
     duplicates,
-    preview: parsed.slice(0, 10),
+    preview: previewCap === 0 ? [] : parsed.slice(0, previewCap),
     dryRun: Boolean(opts.dryRun),
   };
 }

--- a/src/services/importers/index.ts
+++ b/src/services/importers/index.ts
@@ -1,0 +1,451 @@
+// Import service: format detection + orchestration for CSV imports.
+//
+// PRD §4.7: supports Lloyds, NatWest, HSBC, Barclays, Santander, Revolut.
+// Format auto-detection via header signature matching, with --format override.
+// Dedupe against existing transactions via hash of (date, amount, description)
+// when no provider transaction id exists.
+
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { eq } from 'drizzle-orm';
+import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import { getDb } from '../../db/client';
+import { accounts, transactions } from '../../db/schema';
+import * as schema from '../../db/schema';
+import { DataIntegrityError, ValidationError } from '../../lib/errors';
+import { parseBarclays } from './barclays';
+import { isDuplicate } from './dedupe';
+import { parseHsbc } from './hsbc';
+import { parseLloyds } from './lloyds';
+import { parseNatwest } from './natwest';
+import { parseRevolut } from './revolut';
+import { parseSantander } from './santander';
+
+export type BankFormat = 'lloyds' | 'natwest' | 'hsbc' | 'barclays' | 'santander' | 'revolut';
+
+export const BANK_FORMATS: readonly BankFormat[] = [
+  'lloyds',
+  'natwest',
+  'hsbc',
+  'barclays',
+  'santander',
+  'revolut',
+] as const;
+
+export interface ParsedTransaction {
+  date: Date;
+  amount: number; // outflow negative, inflow positive (normalized)
+  description: string;
+  currency?: string; // defaults to GBP if absent
+}
+
+export interface ImportOptions {
+  format?: BankFormat;
+  account?: string;
+  dryRun?: boolean;
+  dedupeStrategy?: 'strict' | 'loose';
+}
+
+export interface ImportResult {
+  format: BankFormat;
+  accountId: string;
+  parsed: number;
+  inserted: number;
+  duplicates: number;
+  preview: ParsedTransaction[];
+  dryRun: boolean;
+}
+
+/**
+ * Strip a UTF-8 BOM if present.
+ */
+export function stripBom(s: string): string {
+  return s.charCodeAt(0) === 0xfeff ? s.slice(1) : s;
+}
+
+/**
+ * Pure-TS RFC-4180-light CSV parser.
+ *
+ * - Handles quoted fields (double quotes around field).
+ * - Handles commas inside quoted fields.
+ * - Handles escaped double quotes ("") inside quoted fields.
+ * - Handles \r\n, \n, and \r row terminators.
+ * - Trims a UTF-8 BOM at the start of the input.
+ * - Returns rows as string[][]. Empty trailing newline is ignored.
+ */
+export function parseCsv(input: string): string[][] {
+  const src = stripBom(input);
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = '';
+  let inQuotes = false;
+  let i = 0;
+  const len = src.length;
+
+  while (i < len) {
+    const ch = src[i] as string;
+    if (inQuotes) {
+      if (ch === '"') {
+        if (i + 1 < len && src[i + 1] === '"') {
+          field += '"';
+          i += 2;
+          continue;
+        }
+        inQuotes = false;
+        i += 1;
+        continue;
+      }
+      field += ch;
+      i += 1;
+      continue;
+    }
+    if (ch === '"') {
+      inQuotes = true;
+      i += 1;
+      continue;
+    }
+    if (ch === ',') {
+      row.push(field);
+      field = '';
+      i += 1;
+      continue;
+    }
+    if (ch === '\r') {
+      // Treat \r or \r\n as row terminator.
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = '';
+      if (i + 1 < len && src[i + 1] === '\n') i += 2;
+      else i += 1;
+      continue;
+    }
+    if (ch === '\n') {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = '';
+      i += 1;
+      continue;
+    }
+    field += ch;
+    i += 1;
+  }
+  // Flush trailing field/row if present.
+  if (field.length > 0 || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+  // Drop a single empty trailing row (from a final newline).
+  if (rows.length > 0) {
+    const last = rows[rows.length - 1];
+    if (last && last.length === 1 && last[0] === '') rows.pop();
+  }
+  return rows;
+}
+
+/**
+ * Detect the bank format from a CSV header line.
+ *
+ * Returns null when no signature matches. Caller must then either ask the user
+ * to specify --format or fail with ValidationError.
+ */
+export function detectFormat(headerLine: string): BankFormat | null {
+  const normalized = stripBom(headerLine).toLowerCase().replace(/\s+/g, ' ').trim();
+
+  // Lloyds: "Transaction Date,Transaction Type,Sort Code,Account Number,Transaction Description,Debit Amount,Credit Amount,Balance"
+  if (
+    normalized.includes('transaction date') &&
+    normalized.includes('debit amount') &&
+    normalized.includes('credit amount') &&
+    normalized.includes('sort code')
+  ) {
+    return 'lloyds';
+  }
+
+  // NatWest: "Date, Type, Description, Value, Balance, Account Name, Account Number"
+  if (
+    normalized.includes('date') &&
+    normalized.includes('account name') &&
+    normalized.includes('account number') &&
+    normalized.includes('value')
+  ) {
+    return 'natwest';
+  }
+
+  // HSBC: "Date,Description,Amount,Balance" or with extra Type column.
+  if (
+    normalized.startsWith('date,') &&
+    normalized.includes('description') &&
+    normalized.includes('amount') &&
+    normalized.includes('balance') &&
+    !normalized.includes('account name') &&
+    !normalized.includes('sort code') &&
+    !normalized.includes('value') &&
+    !normalized.includes('subcategory') &&
+    !normalized.includes('memo')
+  ) {
+    return 'hsbc';
+  }
+
+  // Barclays: "Number,Date,Account,Amount,Subcategory,Memo"
+  if (normalized.includes('subcategory') && normalized.includes('memo')) {
+    return 'barclays';
+  }
+
+  // Santander: "Date: 01/01/2026" header style is unusual. Their CSV (when
+  // exported) typically has: "Date,Description,Amount,Balance" prefixed by
+  // "From: ... To: ..." metadata. We rely on the literal "From:" prefix or the
+  // word "Santander" appearing in the file.
+  if (
+    normalized.startsWith('from:') ||
+    normalized.startsWith('"from:') ||
+    normalized.includes('santander')
+  ) {
+    return 'santander';
+  }
+
+  // Revolut: "Type,Product,Started Date,Completed Date,Description,Amount,Fee,Currency,State,Balance"
+  if (
+    normalized.includes('started date') &&
+    normalized.includes('completed date') &&
+    normalized.includes('amount') &&
+    normalized.includes('currency')
+  ) {
+    return 'revolut';
+  }
+
+  return null;
+}
+
+const PARSERS: Record<BankFormat, (raw: string) => ParsedTransaction[]> = {
+  lloyds: parseLloyds,
+  natwest: parseNatwest,
+  hsbc: parseHsbc,
+  barclays: parseBarclays,
+  santander: parseSantander,
+  revolut: parseRevolut,
+};
+
+/**
+ * Compute a stable id for a CSV-imported transaction. Uses a SHA-256 hash of
+ * (accountId, iso-date, amount, description). This becomes the dedupe key.
+ */
+export function transactionHashId(
+  accountId: string,
+  date: Date,
+  amount: number,
+  description: string,
+): string {
+  const iso = date.toISOString().slice(0, 10); // yyyy-MM-dd
+  const canon = `${accountId}|${iso}|${amount.toFixed(2)}|${description.trim().toLowerCase()}`;
+  return `csv_${createHash('sha256').update(canon).digest('hex').slice(0, 32)}`;
+}
+
+interface OrchestrateDeps {
+  db?: BunSQLiteDatabase<typeof schema>;
+}
+
+/**
+ * Orchestrate the full import: read file, detect format, parse, ensure account,
+ * dedupe, insert. Wrapped in a single DB transaction.
+ */
+export function parseImport(
+  filepath: string,
+  opts: ImportOptions = {},
+  deps: OrchestrateDeps = {},
+): ImportResult {
+  if (!existsSync(filepath)) {
+    throw new ValidationError(`File not found: ${filepath}`);
+  }
+  const raw = readFileSync(filepath, 'utf-8');
+  return runImport(raw, opts, deps);
+}
+
+/**
+ * Same as parseImport but accepts the file contents directly (useful for tests).
+ */
+export function runImport(
+  raw: string,
+  opts: ImportOptions = {},
+  deps: OrchestrateDeps = {},
+): ImportResult {
+  const stripped = stripBom(raw);
+  const lines = stripped.split(/\r?\n/);
+  const headerLine = lines.find((l) => l.trim().length > 0) ?? '';
+
+  const format = opts.format ?? detectFormat(headerLine);
+  if (!format) {
+    throw new ValidationError(
+      'Unable to detect CSV format. Use --format <bank> to specify (lloyds, natwest, hsbc, barclays, santander, revolut).',
+    );
+  }
+  if (!BANK_FORMATS.includes(format)) {
+    throw new ValidationError(`Unknown format: ${format}. Supported: ${BANK_FORMATS.join(', ')}.`);
+  }
+
+  const parser = PARSERS[format];
+  const parsed = parser(stripped);
+
+  const dedupeStrategy: 'strict' | 'loose' = opts.dedupeStrategy ?? 'strict';
+  if (dedupeStrategy !== 'strict' && dedupeStrategy !== 'loose') {
+    throw new ValidationError(
+      `Invalid dedupe strategy: ${dedupeStrategy}. Use 'strict' or 'loose'.`,
+    );
+  }
+
+  const db = deps.db ?? getDb().db;
+
+  // Resolve target account (or create a virtual manual account).
+  const accountId = opts.dryRun
+    ? (opts.account ?? 'manual:dry-run')
+    : ensureAccount(db, opts.account, format);
+
+  // Dedupe within DB.
+  const existing = db
+    .select({
+      id: transactions.id,
+      timestamp: transactions.timestamp,
+      amount: transactions.amount,
+      description: transactions.description,
+    })
+    .from(transactions)
+    .where(eq(transactions.accountId, accountId))
+    .all();
+
+  const existingForDedupe = existing.map((row) => ({
+    id: row.id,
+    date: row.timestamp,
+    amount: row.amount,
+    description: row.description,
+  }));
+
+  let inserted = 0;
+  let duplicates = 0;
+  const toInsert: Array<typeof transactions.$inferInsert> = [];
+  const seenIds = new Set<string>();
+
+  for (const tx of parsed) {
+    if (Number.isNaN(tx.date.getTime())) {
+      throw new DataIntegrityError(
+        `Parsed transaction has invalid date: ${tx.description} / ${String(tx.amount)}`,
+      );
+    }
+    if (!Number.isFinite(tx.amount)) {
+      throw new DataIntegrityError(
+        `Parsed transaction has non-finite amount: ${tx.description} / ${String(tx.amount)}`,
+      );
+    }
+    const id = transactionHashId(accountId, tx.date, tx.amount, tx.description);
+    if (seenIds.has(id)) {
+      duplicates += 1;
+      continue;
+    }
+    seenIds.add(id);
+
+    if (
+      isDuplicate(
+        { id, date: tx.date, amount: tx.amount, description: tx.description },
+        existingForDedupe,
+        dedupeStrategy,
+      )
+    ) {
+      duplicates += 1;
+      continue;
+    }
+
+    toInsert.push({
+      id,
+      accountId,
+      timestamp: tx.date,
+      amount: tx.amount,
+      currency: tx.currency ?? 'GBP',
+      description: tx.description,
+      transactionType: tx.amount < 0 ? 'DEBIT' : 'CREDIT',
+      isPending: false,
+      metadata: { source: 'csv', format },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    inserted += 1;
+  }
+
+  if (!opts.dryRun && toInsert.length > 0) {
+    db.transaction((tx) => {
+      for (const row of toInsert) {
+        tx.insert(transactions).values(row).run();
+      }
+    });
+  }
+
+  return {
+    format,
+    accountId,
+    parsed: parsed.length,
+    inserted: opts.dryRun ? 0 : inserted,
+    duplicates,
+    preview: parsed.slice(0, 10),
+    dryRun: Boolean(opts.dryRun),
+  };
+}
+
+/**
+ * Ensure an account exists for the import target. If `accountId` is provided,
+ * verify it exists. Otherwise create (or reuse) a virtual manual account for
+ * the given format.
+ */
+function ensureAccount(
+  db: BunSQLiteDatabase<typeof schema>,
+  accountId: string | undefined,
+  format: BankFormat,
+): string {
+  if (accountId) {
+    const found = db.select().from(accounts).where(eq(accounts.id, accountId)).all();
+    if (found.length === 0) {
+      throw new ValidationError(`Account not found: ${accountId}`);
+    }
+    return accountId;
+  }
+
+  // Reuse an existing manual account for this format if present.
+  const manualId = `manual:${format}`;
+  const existing = db.select().from(accounts).where(eq(accounts.id, manualId)).all();
+  if (existing.length > 0) return manualId;
+
+  // Create a virtual connection + account for manual imports.
+  const connectionId = `manual:${format}`;
+  const now = new Date();
+  // Insert connection (idempotent via INSERT OR IGNORE-style: we check first).
+  db.transaction((tx) => {
+    const conns = tx
+      .select()
+      .from(schema.connections)
+      .where(eq(schema.connections.id, connectionId))
+      .all();
+    if (conns.length === 0) {
+      tx.insert(schema.connections)
+        .values({
+          id: connectionId,
+          providerId: `manual-${format}`,
+          providerName: format.charAt(0).toUpperCase() + format.slice(1),
+          createdAt: now,
+          // Virtual connection: keep it active forever (no PSD2 expiry for CSV).
+          expiresAt: new Date(now.getTime() + 100 * 365 * 24 * 60 * 60 * 1000),
+          status: 'active',
+        })
+        .run();
+    }
+    tx.insert(accounts)
+      .values({
+        id: manualId,
+        connectionId,
+        accountType: 'TRANSACTION',
+        displayName: `${format.charAt(0).toUpperCase() + format.slice(1)} (manual)`,
+        currency: 'GBP',
+        isManual: true,
+      })
+      .run();
+  });
+
+  return manualId;
+}

--- a/src/services/importers/lloyds.ts
+++ b/src/services/importers/lloyds.ts
@@ -1,0 +1,91 @@
+// Lloyds CSV parser.
+//
+// Header (verified, lloydsbank.com personal current account export):
+//   Transaction Date,Transaction Type,Sort Code,Account Number,Transaction Description,Debit Amount,Credit Amount,Balance
+//
+// Date format: dd/MM/yyyy.
+// Sign convention: Lloyds splits debits and credits into two columns. We
+// normalize: debit -> negative, credit -> positive, single 'amount' field.
+
+import { ValidationError } from '../../lib/errors';
+import { type ParsedTransaction, parseCsv } from './index';
+
+const HEADER_INDEXES = {
+  date: 0,
+  type: 1,
+  sortCode: 2,
+  accountNumber: 3,
+  description: 4,
+  debit: 5,
+  credit: 6,
+  balance: 7,
+} as const;
+
+export function parseLloyds(raw: string): ParsedTransaction[] {
+  const rows = parseCsv(raw);
+  if (rows.length === 0) return [];
+
+  // Locate header row (skip blank leading rows if any).
+  let headerIdx = -1;
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    if (row?.some((c) => c.toLowerCase().includes('transaction date'))) {
+      headerIdx = i;
+      break;
+    }
+  }
+  if (headerIdx === -1) {
+    throw new ValidationError('Lloyds parser: header row not found');
+  }
+
+  const out: ParsedTransaction[] = [];
+  for (let i = headerIdx + 1; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row || row.every((c) => c.trim() === '')) continue;
+    if (row.length < 7) continue;
+
+    const dateStr = (row[HEADER_INDEXES.date] ?? '').trim();
+    const description = (row[HEADER_INDEXES.description] ?? '').trim();
+    const debitStr = (row[HEADER_INDEXES.debit] ?? '').trim();
+    const creditStr = (row[HEADER_INDEXES.credit] ?? '').trim();
+
+    if (!dateStr) continue;
+
+    const date = parseUkDate(dateStr);
+    const debit = parseFloatSafe(debitStr);
+    const credit = parseFloatSafe(creditStr);
+
+    let amount = 0;
+    if (debit > 0) amount = -debit;
+    else if (credit > 0) amount = credit;
+    else amount = 0;
+
+    out.push({
+      date,
+      amount,
+      description,
+      currency: 'GBP',
+    });
+  }
+  return out;
+}
+
+function parseUkDate(s: string): Date {
+  // dd/MM/yyyy
+  const m = /^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/.exec(s);
+  if (!m) throw new ValidationError(`Lloyds parser: invalid date '${s}'`);
+  const day = Number.parseInt(m[1] as string, 10);
+  const month = Number.parseInt(m[2] as string, 10);
+  let year = Number.parseInt(m[3] as string, 10);
+  if (year < 100) year += 2000;
+  // Construct as UTC midnight to avoid timezone drift.
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function parseFloatSafe(s: string): number {
+  if (!s) return 0;
+  const cleaned = s.replace(/[£,]/g, '').trim();
+  if (!cleaned) return 0;
+  const n = Number.parseFloat(cleaned);
+  return Number.isFinite(n) ? n : 0;
+}

--- a/src/services/importers/lloyds.ts
+++ b/src/services/importers/lloyds.ts
@@ -9,6 +9,7 @@
 
 import { ValidationError } from '../../lib/errors';
 import { type ParsedTransaction, parseCsv } from './index';
+import { parseFloatSafe, parseUkDate } from './uk-date';
 
 const HEADER_INDEXES = {
   date: 0,
@@ -51,9 +52,9 @@ export function parseLloyds(raw: string): ParsedTransaction[] {
 
     if (!dateStr) continue;
 
-    const date = parseUkDate(dateStr);
-    const debit = parseFloatSafe(debitStr);
-    const credit = parseFloatSafe(creditStr);
+    const date = parseUkDate(dateStr, 'Lloyds');
+    const debit = parseFloatSafe(debitStr, 'Lloyds', i + 1);
+    const credit = parseFloatSafe(creditStr, 'Lloyds', i + 1);
 
     let amount = 0;
     if (debit > 0) amount = -debit;
@@ -68,24 +69,4 @@ export function parseLloyds(raw: string): ParsedTransaction[] {
     });
   }
   return out;
-}
-
-function parseUkDate(s: string): Date {
-  // dd/MM/yyyy
-  const m = /^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/.exec(s);
-  if (!m) throw new ValidationError(`Lloyds parser: invalid date '${s}'`);
-  const day = Number.parseInt(m[1] as string, 10);
-  const month = Number.parseInt(m[2] as string, 10);
-  let year = Number.parseInt(m[3] as string, 10);
-  if (year < 100) year += 2000;
-  // Construct as UTC midnight to avoid timezone drift.
-  return new Date(Date.UTC(year, month - 1, day));
-}
-
-function parseFloatSafe(s: string): number {
-  if (!s) return 0;
-  const cleaned = s.replace(/[£,]/g, '').trim();
-  if (!cleaned) return 0;
-  const n = Number.parseFloat(cleaned);
-  return Number.isFinite(n) ? n : 0;
 }

--- a/src/services/importers/natwest.ts
+++ b/src/services/importers/natwest.ts
@@ -9,6 +9,7 @@
 
 import { ValidationError } from '../../lib/errors';
 import { type ParsedTransaction, parseCsv } from './index';
+import { parseFloatSafe, parseUkDate } from './uk-date';
 
 export function parseNatwest(raw: string): ParsedTransaction[] {
   const rows = parseCsv(raw);
@@ -54,29 +55,11 @@ export function parseNatwest(raw: string): ParsedTransaction[] {
     if (!dateStr) continue;
 
     out.push({
-      date: parseUkDate(dateStr),
-      amount: parseFloatSafe(valueStr),
+      date: parseUkDate(dateStr, 'NatWest'),
+      amount: parseFloatSafe(valueStr, 'NatWest', i + 1),
       description,
       currency: 'GBP',
     });
   }
   return out;
-}
-
-function parseUkDate(s: string): Date {
-  const m = /^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/.exec(s);
-  if (!m) throw new ValidationError(`NatWest parser: invalid date '${s}'`);
-  const day = Number.parseInt(m[1] as string, 10);
-  const month = Number.parseInt(m[2] as string, 10);
-  let year = Number.parseInt(m[3] as string, 10);
-  if (year < 100) year += 2000;
-  return new Date(Date.UTC(year, month - 1, day));
-}
-
-function parseFloatSafe(s: string): number {
-  if (!s) return 0;
-  const cleaned = s.replace(/[£,]/g, '').trim();
-  if (!cleaned) return 0;
-  const n = Number.parseFloat(cleaned);
-  return Number.isFinite(n) ? n : 0;
 }

--- a/src/services/importers/natwest.ts
+++ b/src/services/importers/natwest.ts
@@ -1,0 +1,82 @@
+// NatWest CSV parser.
+//
+// Header (verified, NatWest online banking transaction download):
+//   Date, Type, Description, Value, Balance, Account Name, Account Number
+//
+// Date format: dd/MM/yyyy.
+// Sign convention: NatWest uses a single signed 'Value' column where debits
+// are already negative. We pass through.
+
+import { ValidationError } from '../../lib/errors';
+import { type ParsedTransaction, parseCsv } from './index';
+
+export function parseNatwest(raw: string): ParsedTransaction[] {
+  const rows = parseCsv(raw);
+  if (rows.length === 0) return [];
+
+  let headerIdx = -1;
+  let headers: string[] = [];
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row) continue;
+    const lower = row.map((c) => c.trim().toLowerCase());
+    if (
+      lower.includes('date') &&
+      lower.includes('value') &&
+      (lower.includes('account name') || lower.includes('account number'))
+    ) {
+      headerIdx = i;
+      headers = lower;
+      break;
+    }
+  }
+  if (headerIdx === -1) {
+    throw new ValidationError('NatWest parser: header row not found');
+  }
+
+  const idx = {
+    date: headers.indexOf('date'),
+    description: headers.indexOf('description'),
+    value: headers.indexOf('value'),
+  };
+  if (idx.date === -1 || idx.description === -1 || idx.value === -1) {
+    throw new ValidationError('NatWest parser: missing required columns');
+  }
+
+  const out: ParsedTransaction[] = [];
+  for (let i = headerIdx + 1; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row || row.every((c) => c.trim() === '')) continue;
+
+    const dateStr = (row[idx.date] ?? '').trim();
+    const description = (row[idx.description] ?? '').trim();
+    const valueStr = (row[idx.value] ?? '').trim();
+    if (!dateStr) continue;
+
+    out.push({
+      date: parseUkDate(dateStr),
+      amount: parseFloatSafe(valueStr),
+      description,
+      currency: 'GBP',
+    });
+  }
+  return out;
+}
+
+function parseUkDate(s: string): Date {
+  const m = /^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/.exec(s);
+  if (!m) throw new ValidationError(`NatWest parser: invalid date '${s}'`);
+  const day = Number.parseInt(m[1] as string, 10);
+  const month = Number.parseInt(m[2] as string, 10);
+  let year = Number.parseInt(m[3] as string, 10);
+  if (year < 100) year += 2000;
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function parseFloatSafe(s: string): number {
+  if (!s) return 0;
+  const cleaned = s.replace(/[£,]/g, '').trim();
+  if (!cleaned) return 0;
+  const n = Number.parseFloat(cleaned);
+  return Number.isFinite(n) ? n : 0;
+}

--- a/src/services/importers/revolut.ts
+++ b/src/services/importers/revolut.ts
@@ -1,0 +1,112 @@
+// Revolut CSV parser.
+//
+// Header (verified, Revolut personal account export, 2024+ format):
+//   Type,Product,Started Date,Completed Date,Description,Amount,Fee,Currency,State,Balance
+//
+// Date format: yyyy-MM-dd HH:mm:ss (UTC).
+// Sign convention: Revolut uses signed Amount (negative = outflow). Pass through.
+// Currency varies per row (multi-currency), so we surface the per-row Currency.
+// State filter: only include 'COMPLETED' rows (skip PENDING/REVERTED/DECLINED).
+
+import { ValidationError } from '../../lib/errors';
+import { type ParsedTransaction, parseCsv } from './index';
+
+export function parseRevolut(raw: string): ParsedTransaction[] {
+  const rows = parseCsv(raw);
+  if (rows.length === 0) return [];
+
+  let headerIdx = -1;
+  let headers: string[] = [];
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row) continue;
+    const lower = row.map((c) => c.trim().toLowerCase());
+    if (
+      lower.includes('started date') &&
+      lower.includes('completed date') &&
+      lower.includes('amount')
+    ) {
+      headerIdx = i;
+      headers = lower;
+      break;
+    }
+  }
+  if (headerIdx === -1) {
+    throw new ValidationError('Revolut parser: header row not found');
+  }
+
+  const idx = {
+    completed: headers.indexOf('completed date'),
+    started: headers.indexOf('started date'),
+    description: headers.indexOf('description'),
+    amount: headers.indexOf('amount'),
+    fee: headers.indexOf('fee'),
+    currency: headers.indexOf('currency'),
+    state: headers.indexOf('state'),
+  };
+  if (idx.amount === -1) {
+    throw new ValidationError('Revolut parser: missing Amount column');
+  }
+
+  const out: ParsedTransaction[] = [];
+  for (let i = headerIdx + 1; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row || row.every((c) => c.trim() === '')) continue;
+
+    if (idx.state !== -1) {
+      const state = (row[idx.state] ?? '').trim().toUpperCase();
+      if (state && state !== 'COMPLETED') continue;
+    }
+
+    const dateStr =
+      (idx.completed !== -1 ? row[idx.completed] : undefined) ??
+      (idx.started !== -1 ? row[idx.started] : undefined) ??
+      '';
+    const date = parseRevolutDate(String(dateStr).trim());
+    const amount = parseFloatSafe(String(row[idx.amount] ?? '').trim());
+    const fee = idx.fee !== -1 ? parseFloatSafe(String(row[idx.fee] ?? '').trim()) : 0;
+    const description = idx.description !== -1 ? String(row[idx.description] ?? '').trim() : '';
+    const currency =
+      idx.currency !== -1
+        ? String(row[idx.currency] ?? '')
+            .trim()
+            .toUpperCase()
+        : 'GBP';
+
+    // Revolut Amount is the net (without fee) in the export. Subtract fee for
+    // outflows so the recorded amount matches what left the account.
+    const net = amount - fee;
+
+    out.push({
+      date,
+      amount: net,
+      description,
+      currency: currency || 'GBP',
+    });
+  }
+  return out;
+}
+
+function parseRevolutDate(s: string): Date {
+  // yyyy-MM-dd HH:mm:ss or yyyy-MM-dd or ISO with 'T'.
+  if (!s) throw new ValidationError('Revolut parser: empty date');
+  const isoLike = s.replace(' ', 'T');
+  const d = new Date(isoLike.endsWith('Z') ? isoLike : `${isoLike}Z`);
+  if (Number.isNaN(d.getTime())) {
+    // Fallback: try plain Date parsing.
+    const d2 = new Date(s);
+    if (Number.isNaN(d2.getTime())) {
+      throw new ValidationError(`Revolut parser: invalid date '${s}'`);
+    }
+    return d2;
+  }
+  return d;
+}
+
+function parseFloatSafe(s: string): number {
+  if (!s) return 0;
+  const cleaned = s.replace(/[£$€,]/g, '').trim();
+  if (!cleaned) return 0;
+  const n = Number.parseFloat(cleaned);
+  return Number.isFinite(n) ? n : 0;
+}

--- a/src/services/importers/revolut.ts
+++ b/src/services/importers/revolut.ts
@@ -108,5 +108,8 @@ function parseFloatSafe(s: string): number {
   const cleaned = s.replace(/[£$€,]/g, '').trim();
   if (!cleaned) return 0;
   const n = Number.parseFloat(cleaned);
-  return Number.isFinite(n) ? n : 0;
+  if (!Number.isFinite(n) || !/^[+-]?(?:\d+\.?\d*|\.\d+)$/.test(cleaned)) {
+    throw new ValidationError(`Revolut parser: invalid amount '${s}'`);
+  }
+  return n;
 }

--- a/src/services/importers/santander.ts
+++ b/src/services/importers/santander.ts
@@ -1,0 +1,136 @@
+// Santander CSV parser.
+//
+// TODO: validate against real export.
+//
+// Santander UK exports are unusual: their downloadable .txt/.csv format begins
+// with a metadata block (From: ... To: ... Account: ... ) followed by
+// per-transaction blocks separated by blank lines:
+//   Date: 31/03/2026
+//   Description: GROCERIES
+//   Amount: -45.20
+//   Balance: 1234.56
+//
+// We support BOTH this block format AND a plainer comma-separated header form
+// (Date,Description,Amount,Balance) in case the user pre-converts the export.
+//
+// Date format: dd/MM/yyyy.
+// Sign convention: signed amount, debits negative.
+
+import { ValidationError } from '../../lib/errors';
+import { type ParsedTransaction, parseCsv } from './index';
+
+export function parseSantander(raw: string): ParsedTransaction[] {
+  // Detect block format vs CSV format. Block format has lines like "Date:" and
+  // "Amount:" not in CSV header form.
+  const looksLikeBlocks = /\bAmount:/i.test(raw) && /\bDate:/i.test(raw);
+  if (looksLikeBlocks) {
+    return parseBlocks(raw);
+  }
+  return parseCsvForm(raw);
+}
+
+function parseBlocks(raw: string): ParsedTransaction[] {
+  const out: ParsedTransaction[] = [];
+  const lines = raw.split(/\r?\n/);
+  let date: Date | null = null;
+  let description = '';
+  let amount: number | null = null;
+
+  const flush = () => {
+    if (date && amount !== null) {
+      out.push({ date, amount, description, currency: 'GBP' });
+    }
+    date = null;
+    description = '';
+    amount = null;
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) {
+      flush();
+      continue;
+    }
+    const m = /^([A-Za-z][A-Za-z ]*?):\s*(.*)$/.exec(line);
+    if (!m) continue;
+    const key = (m[1] as string).trim().toLowerCase();
+    const value = (m[2] as string).trim();
+
+    switch (key) {
+      case 'date':
+        date = parseUkDate(value);
+        break;
+      case 'description':
+        description = value;
+        break;
+      case 'amount':
+        amount = parseFloatSafe(value);
+        break;
+      default:
+        // Ignore Balance, From, To, Account, etc.
+        break;
+    }
+  }
+  flush();
+  return out;
+}
+
+function parseCsvForm(raw: string): ParsedTransaction[] {
+  const rows = parseCsv(raw);
+  if (rows.length === 0) return [];
+
+  let headerIdx = -1;
+  let headers: string[] = [];
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row) continue;
+    const lower = row.map((c) => c.trim().toLowerCase());
+    if (lower.includes('date') && lower.includes('description') && lower.includes('amount')) {
+      headerIdx = i;
+      headers = lower;
+      break;
+    }
+  }
+  if (headerIdx === -1) {
+    throw new ValidationError('Santander parser: header row not found');
+  }
+
+  const idx = {
+    date: headers.indexOf('date'),
+    description: headers.indexOf('description'),
+    amount: headers.indexOf('amount'),
+  };
+
+  const out: ParsedTransaction[] = [];
+  for (let i = headerIdx + 1; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row || row.every((c) => c.trim() === '')) continue;
+    const dateStr = (row[idx.date] ?? '').trim();
+    if (!dateStr) continue;
+    out.push({
+      date: parseUkDate(dateStr),
+      amount: parseFloatSafe((row[idx.amount] ?? '').trim()),
+      description: (row[idx.description] ?? '').trim(),
+      currency: 'GBP',
+    });
+  }
+  return out;
+}
+
+function parseUkDate(s: string): Date {
+  const m = /^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/.exec(s);
+  if (!m) throw new ValidationError(`Santander parser: invalid date '${s}'`);
+  const day = Number.parseInt(m[1] as string, 10);
+  const month = Number.parseInt(m[2] as string, 10);
+  let year = Number.parseInt(m[3] as string, 10);
+  if (year < 100) year += 2000;
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function parseFloatSafe(s: string): number {
+  if (!s) return 0;
+  const cleaned = s.replace(/[£,]/g, '').trim();
+  if (!cleaned) return 0;
+  const n = Number.parseFloat(cleaned);
+  return Number.isFinite(n) ? n : 0;
+}

--- a/src/services/importers/santander.ts
+++ b/src/services/importers/santander.ts
@@ -18,6 +18,7 @@
 
 import { ValidationError } from '../../lib/errors';
 import { type ParsedTransaction, parseCsv } from './index';
+import { parseFloatSafe, parseUkDate } from './uk-date';
 
 export function parseSantander(raw: string): ParsedTransaction[] {
   // Detect block format vs CSV format. Block format has lines like "Date:" and
@@ -58,13 +59,13 @@ function parseBlocks(raw: string): ParsedTransaction[] {
 
     switch (key) {
       case 'date':
-        date = parseUkDate(value);
+        date = parseUkDate(value, 'Santander');
         break;
       case 'description':
         description = value;
         break;
       case 'amount':
-        amount = parseFloatSafe(value);
+        amount = parseFloatSafe(value, 'Santander');
         break;
       default:
         // Ignore Balance, From, To, Account, etc.
@@ -108,29 +109,11 @@ function parseCsvForm(raw: string): ParsedTransaction[] {
     const dateStr = (row[idx.date] ?? '').trim();
     if (!dateStr) continue;
     out.push({
-      date: parseUkDate(dateStr),
-      amount: parseFloatSafe((row[idx.amount] ?? '').trim()),
+      date: parseUkDate(dateStr, 'Santander'),
+      amount: parseFloatSafe((row[idx.amount] ?? '').trim(), 'Santander', i + 1),
       description: (row[idx.description] ?? '').trim(),
       currency: 'GBP',
     });
   }
   return out;
-}
-
-function parseUkDate(s: string): Date {
-  const m = /^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/.exec(s);
-  if (!m) throw new ValidationError(`Santander parser: invalid date '${s}'`);
-  const day = Number.parseInt(m[1] as string, 10);
-  const month = Number.parseInt(m[2] as string, 10);
-  let year = Number.parseInt(m[3] as string, 10);
-  if (year < 100) year += 2000;
-  return new Date(Date.UTC(year, month - 1, day));
-}
-
-function parseFloatSafe(s: string): number {
-  if (!s) return 0;
-  const cleaned = s.replace(/[£,]/g, '').trim();
-  if (!cleaned) return 0;
-  const n = Number.parseFloat(cleaned);
-  return Number.isFinite(n) ? n : 0;
 }

--- a/src/services/importers/uk-date.ts
+++ b/src/services/importers/uk-date.ts
@@ -1,0 +1,56 @@
+// Shared helpers for UK-format CSV importers (Barclays, HSBC, etc).
+//
+// Why a shared module: the Barclays / HSBC parsers used to each ship their own
+// `parseUkDate` and `parseFloatSafe` copies. They were near-identical and drifted
+// over time, which made fixes (validation, error reporting) inconsistent. This
+// module is the single source of truth — fixes here apply to every importer.
+
+import { ValidationError } from '../../lib/errors';
+
+/**
+ * Parse a UK-format date string `dd/MM/yyyy` (also tolerates `dd/MM/yy`).
+ *
+ * Validates that the parsed components round-trip back to the same date. e.g.
+ * `32/13/2026` no longer silently becomes a future date — it throws.
+ *
+ * @param s          Raw date string from the CSV cell.
+ * @param parserName Name of the calling parser (for error messages).
+ */
+export function parseUkDate(s: string, parserName: string): Date {
+  const m = /^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/.exec(s);
+  if (!m) throw new ValidationError(`${parserName} parser: invalid date '${s}'`);
+  const day = Number.parseInt(m[1] as string, 10);
+  const month = Number.parseInt(m[2] as string, 10);
+  let year = Number.parseInt(m[3] as string, 10);
+  if (year < 100) year += 2000;
+
+  const d = new Date(Date.UTC(year, month - 1, day));
+  // Round-trip check: rejects e.g. 32/13/2026, 30/02/2026, etc.
+  if (d.getUTCFullYear() !== year || d.getUTCMonth() !== month - 1 || d.getUTCDate() !== day) {
+    throw new ValidationError(`${parserName} parser: invalid date '${s}'`);
+  }
+  return d;
+}
+
+/**
+ * Parse a numeric amount cell. Strips `£` and thousands separators.
+ *
+ * Empty or whitespace-only cells return `0` (banks emit empty cells for
+ * unused debit/credit columns). Non-empty cells that fail to parse throw a
+ * `ValidationError` rather than silently corrupting to `0`.
+ *
+ * @param s          Raw amount string from the CSV cell.
+ * @param parserName Name of the calling parser (for error messages).
+ * @param rowNumber  1-based row number for the error message (optional).
+ */
+export function parseFloatSafe(s: string, parserName: string, rowNumber?: number): number {
+  if (!s) return 0;
+  const cleaned = s.replace(/[£,]/g, '').trim();
+  if (!cleaned) return 0;
+  const n = Number.parseFloat(cleaned);
+  if (!Number.isFinite(n) || !/^[+-]?(?:\d+\.?\d*|\.\d+)$/.test(cleaned)) {
+    const at = rowNumber !== undefined ? ` at row ${rowNumber}` : '';
+    throw new ValidationError(`${parserName} parser: invalid amount '${s}'${at}`);
+  }
+  return n;
+}

--- a/tests/unit/csv-parser.test.ts
+++ b/tests/unit/csv-parser.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import { parseCsv, stripBom } from '../../src/services/importers';
+
+describe('parseCsv', () => {
+  test('round-trip: handles quoted commas and escaped quotes', () => {
+    const csv = ['a,b,c', '"hello, world","she said ""hi""",42', 'plain,"with\nnewline",end'].join(
+      '\n',
+    );
+    const rows = parseCsv(csv);
+    expect(rows).toEqual([
+      ['a', 'b', 'c'],
+      ['hello, world', 'she said "hi"', '42'],
+      ['plain', 'with\nnewline', 'end'],
+    ]);
+  });
+
+  test('strips a UTF-8 BOM at the start of the input', () => {
+    const csv = '\ufeffa,b\n1,2';
+    expect(stripBom(csv)).toBe('a,b\n1,2');
+    const rows = parseCsv(csv);
+    expect(rows).toEqual([
+      ['a', 'b'],
+      ['1', '2'],
+    ]);
+  });
+
+  test('handles \\r\\n and \\r row terminators', () => {
+    expect(parseCsv('a,b\r\n1,2\r\n')).toEqual([
+      ['a', 'b'],
+      ['1', '2'],
+    ]);
+    expect(parseCsv('a,b\r1,2\r')).toEqual([
+      ['a', 'b'],
+      ['1', '2'],
+    ]);
+  });
+
+  test('preserves empty trailing fields', () => {
+    expect(parseCsv('a,b,c\n1,,3\n')).toEqual([
+      ['a', 'b', 'c'],
+      ['1', '', '3'],
+    ]);
+  });
+
+  test('returns empty array for empty input', () => {
+    expect(parseCsv('')).toEqual([]);
+  });
+
+  test('handles single row without terminator', () => {
+    expect(parseCsv('one,two')).toEqual([['one', 'two']]);
+  });
+});

--- a/tests/unit/export-cmd.test.ts
+++ b/tests/unit/export-cmd.test.ts
@@ -1,0 +1,171 @@
+import { Database } from 'bun:sqlite';
+import { afterAll, beforeAll, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const tmp = mkdtempSync(join(tmpdir(), 'ferret-export-'));
+const FERRET_HOME = join(tmp, '.ferret');
+const DB_PATH = join(FERRET_HOME, 'ferret.db');
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+beforeAll(() => {
+  // Run `ferret init` in a clean subprocess so that the resulting DB lives at
+  // the temp HOME, then seed transactions directly into that on-disk DB.
+  const env = subprocessEnv();
+  const initRes = Bun.spawnSync({
+    cmd: ['bun', 'run', join(projectRoot, 'src', 'cli.ts'), 'init'],
+    cwd: projectRoot,
+    env,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  if (initRes.exitCode !== 0) {
+    throw new Error(`init failed: ${initRes.stderr.toString()}`);
+  }
+
+  // Seed test transactions via raw sqlite at DB_PATH (timestamps stored as
+  // unix-seconds because drizzle uses {mode: 'timestamp'} -> integer seconds).
+  const raw = new Database(DB_PATH);
+  raw.exec('PRAGMA foreign_keys = ON;');
+  const now = Math.floor(Date.now() / 1000);
+
+  raw
+    .prepare(
+      'INSERT INTO connections (id, provider_id, provider_name, created_at, expires_at, status) VALUES (?, ?, ?, ?, ?, ?)',
+    )
+    .run('conn1', 'manual-test', 'Test', now, now + 86400, 'active');
+
+  raw
+    .prepare(
+      'INSERT INTO accounts (id, connection_id, account_type, display_name, currency, is_manual) VALUES (?, ?, ?, ?, ?, ?)',
+    )
+    .run('acct1', 'conn1', 'TRANSACTION', 'Test Account', 'GBP', 1);
+
+  const seedTxn = raw.prepare(
+    'INSERT INTO transactions (id, account_id, timestamp, amount, currency, description, category, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+  );
+  seedTxn.run(
+    'tx1',
+    'acct1',
+    Math.floor(Date.UTC(2026, 3, 15) / 1000),
+    -12.5,
+    'GBP',
+    'TESCO, STORES',
+    'Groceries',
+    now,
+    now,
+  );
+  seedTxn.run(
+    'tx2',
+    'acct1',
+    Math.floor(Date.UTC(2026, 3, 16) / 1000),
+    25,
+    'GBP',
+    'REFUND "FROM" SHOP',
+    'Income',
+    now,
+    now,
+  );
+  seedTxn.run(
+    'tx3',
+    'acct1',
+    Math.floor(Date.UTC(2026, 4, 1) / 1000),
+    -5,
+    'GBP',
+    'OUT OF RANGE',
+    'Other',
+    now,
+    now,
+  );
+  raw.close();
+});
+
+afterAll(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function subprocessEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) if (v !== undefined) env[k] = v;
+  env.HOME = tmp;
+  env.NO_COLOR = '1';
+  env.NODE_ENV = 'production';
+  return env;
+}
+
+function runExport(args: string[]): { stdout: string; stderr: string; exitCode: number } {
+  const res = Bun.spawnSync({
+    cmd: ['bun', 'run', join(projectRoot, 'src', 'cli.ts'), 'export', ...args],
+    cwd: projectRoot,
+    env: subprocessEnv(),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  return {
+    stdout: res.stdout.toString(),
+    stderr: res.stderr.toString(),
+    exitCode: res.exitCode ?? 0,
+  };
+}
+
+test('export CSV: round-trips seeded transactions, escaping quotes/commas correctly', async () => {
+  const { stdout, stderr, exitCode } = runExport(['--format', 'csv']);
+  if (exitCode !== 0) throw new Error(`export failed: ${stderr}`);
+  if (stdout.trim().length === 0) throw new Error(`empty stdout. stderr=${stderr}`);
+
+  const { parseCsv } = await import('../../src/services/importers');
+  const rows = parseCsv(stdout);
+  expect(rows.length).toBeGreaterThanOrEqual(4); // header + 3 rows
+
+  const header = rows[0] ?? [];
+  expect(header).toContain('id');
+  expect(header).toContain('amount');
+  expect(header).toContain('description');
+  expect(header).toContain('category');
+  expect(header).toContain('source');
+
+  const dataRows = rows.slice(1);
+  const idIdx = header.indexOf('id');
+  const descIdx = header.indexOf('description');
+  const amtIdx = header.indexOf('amount');
+  const catIdx = header.indexOf('category');
+  const srcIdx = header.indexOf('source');
+
+  const tx1 = dataRows.find((r) => r[idIdx] === 'tx1');
+  const tx2 = dataRows.find((r) => r[idIdx] === 'tx2');
+  expect(tx1?.[descIdx]).toBe('TESCO, STORES');
+  expect(tx1?.[amtIdx]).toBe('-12.5');
+  expect(tx1?.[catIdx]).toBe('Groceries');
+  expect(tx1?.[srcIdx]).toBe('csv');
+
+  expect(tx2?.[descIdx]).toBe('REFUND "FROM" SHOP');
+  expect(tx2?.[amtIdx]).toBe('25');
+});
+
+test('export CSV --since/--until filters by date range', async () => {
+  const { stdout, stderr, exitCode } = runExport([
+    '--format',
+    'csv',
+    '--since',
+    '2026-04-01',
+    '--until',
+    '2026-04-30',
+  ]);
+  if (exitCode !== 0) throw new Error(`export failed: ${stderr}`);
+  const { parseCsv } = await import('../../src/services/importers');
+  const rows = parseCsv(stdout);
+  // header + 2 in-range (tx1, tx2). tx3 is May 1 -> excluded.
+  expect(rows.length).toBe(3);
+});
+
+test('export JSON outputs a parseable array', async () => {
+  const { stdout, stderr, exitCode } = runExport(['--format', 'json']);
+  if (exitCode !== 0) throw new Error(`export failed: ${stderr}`);
+  const parsed = JSON.parse(stdout) as Array<Record<string, unknown>>;
+  expect(Array.isArray(parsed)).toBe(true);
+  expect(parsed.length).toBeGreaterThanOrEqual(3);
+  expect(parsed[0]).toHaveProperty('id');
+  expect(parsed[0]).toHaveProperty('source');
+});

--- a/tests/unit/import-cmd.test.ts
+++ b/tests/unit/import-cmd.test.ts
@@ -113,3 +113,28 @@ test('parseImport throws ValidationError when file does not exist', async () => 
   const { db } = getDb(DB_PATH);
   expect(() => parseImport(join(tmp, 'nonexistent.csv'), {}, { db })).toThrow(/File not found/);
 });
+
+test('parseImport honours previewRows option (dry-run preview cap)', async () => {
+  // Build a CSV with 12 rows to exercise both default cap (10) and a custom 3.
+  const header =
+    'Transaction Date,Transaction Type,Sort Code,Account Number,Transaction Description,Debit Amount,Credit Amount,Balance';
+  const lines = [header];
+  for (let i = 1; i <= 12; i++) {
+    const dd = String(i).padStart(2, '0');
+    lines.push(`${dd}/05/2026,DEB,30-99-50,12345678,PREVIEW ROW ${i},1.00,,100.00`);
+  }
+  const csvPath = join(tmp, 'lloyds-preview.csv');
+  writeFileSync(csvPath, lines.join('\n'));
+
+  const { parseImport } = await import('../../src/services/importers');
+  const { db } = getDb(DB_PATH);
+
+  const def = parseImport(csvPath, { format: 'lloyds', dryRun: true }, { db });
+  expect(def.preview.length).toBe(10);
+
+  const custom = parseImport(csvPath, { format: 'lloyds', dryRun: true, previewRows: 3 }, { db });
+  expect(custom.preview.length).toBe(3);
+
+  const zero = parseImport(csvPath, { format: 'lloyds', dryRun: true, previewRows: 0 }, { db });
+  expect(zero.preview.length).toBe(0);
+});

--- a/tests/unit/import-cmd.test.ts
+++ b/tests/unit/import-cmd.test.ts
@@ -1,0 +1,115 @@
+import { afterAll, beforeAll, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { migrate } from 'drizzle-orm/bun-sqlite/migrator';
+import { getDb, resetDbCache } from '../../src/db/client';
+
+const tmp = mkdtempSync(join(tmpdir(), 'ferret-import-'));
+const DB_PATH = join(tmp, 'ferret.db');
+
+const LLOYDS_FIXTURE = [
+  'Transaction Date,Transaction Type,Sort Code,Account Number,Transaction Description,Debit Amount,Credit Amount,Balance',
+  '15/04/2026,DEB,30-99-50,12345678,TESCO STORES,12.50,,1234.56',
+  '16/04/2026,FPI,30-99-50,12345678,SALARY,,2500.00,3734.56',
+].join('\n');
+
+function migrationsFolder(): string {
+  const here = fileURLToPath(new URL('.', import.meta.url));
+  return join(here, '..', '..', 'src', 'db', 'migrations');
+}
+
+beforeAll(() => {
+  // Tests share a Bun process with frozen DB_PATH constants in client.ts.
+  // Bypass that by passing an explicit dbPath to getDb() and threading it
+  // through parseImport via deps.db.
+  resetDbCache();
+  const { db } = getDb(DB_PATH);
+  migrate(db, { migrationsFolder: migrationsFolder() });
+});
+
+afterAll(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+test('parseImport inserts CSV rows into a virtual manual account', async () => {
+  const csvPath = join(tmp, 'lloyds.csv');
+  writeFileSync(csvPath, LLOYDS_FIXTURE);
+
+  const { parseImport } = await import('../../src/services/importers');
+  const { db, raw } = getDb(DB_PATH);
+  const result = parseImport(csvPath, { format: 'lloyds' }, { db });
+
+  expect(result.format).toBe('lloyds');
+  expect(result.parsed).toBe(2);
+  expect(result.inserted).toBe(2);
+  expect(result.duplicates).toBe(0);
+
+  const rows = raw
+    .prepare('SELECT amount, description FROM transactions WHERE account_id = ?')
+    .all(result.accountId) as Array<{ amount: number; description: string }>;
+  expect(rows.length).toBe(2);
+  const tesco = rows.find((r) => r.description === 'TESCO STORES');
+  const salary = rows.find((r) => r.description === 'SALARY');
+  expect(tesco?.amount).toBe(-12.5);
+  expect(salary?.amount).toBe(2500);
+});
+
+test('parseImport is idempotent: re-importing same file yields all duplicates', async () => {
+  const csv = [
+    'Transaction Date,Transaction Type,Sort Code,Account Number,Transaction Description,Debit Amount,Credit Amount,Balance',
+    '01/01/2026,DEB,30-99-50,12345678,IDEMPOTENT A,1.00,,1.00',
+    '02/01/2026,DEB,30-99-50,12345678,IDEMPOTENT B,2.00,,2.00',
+  ].join('\n');
+  const csvPath = join(tmp, 'lloyds-2.csv');
+  writeFileSync(csvPath, csv);
+
+  const { parseImport } = await import('../../src/services/importers');
+  const { db } = getDb(DB_PATH);
+  const first = parseImport(csvPath, { format: 'lloyds' }, { db });
+  expect(first.inserted).toBe(2);
+
+  const second = parseImport(csvPath, { format: 'lloyds' }, { db });
+  expect(second.inserted).toBe(0);
+  expect(second.duplicates).toBe(2);
+});
+
+test('parseImport --dry-run does not insert', async () => {
+  const csvPath = join(tmp, 'lloyds-3.csv');
+  writeFileSync(
+    csvPath,
+    [
+      'Transaction Date,Transaction Type,Sort Code,Account Number,Transaction Description,Debit Amount,Credit Amount,Balance',
+      '20/04/2026,DEB,30-99-50,12345678,DRYRUN ONLY,1.00,,100.00',
+    ].join('\n'),
+  );
+
+  const { parseImport } = await import('../../src/services/importers');
+  const { db, raw } = getDb(DB_PATH);
+  const result = parseImport(csvPath, { format: 'lloyds', dryRun: true }, { db });
+
+  expect(result.dryRun).toBe(true);
+  expect(result.inserted).toBe(0);
+  expect(result.parsed).toBe(1);
+
+  const matches = raw
+    .prepare('SELECT COUNT(*) as n FROM transactions WHERE description = ?')
+    .get('DRYRUN ONLY') as { n: number };
+  expect(matches.n).toBe(0);
+});
+
+test('parseImport throws ValidationError when format cannot be detected', async () => {
+  const csvPath = join(tmp, 'unknown.csv');
+  writeFileSync(csvPath, 'foo,bar\n1,2\n');
+
+  const { parseImport } = await import('../../src/services/importers');
+  const { db } = getDb(DB_PATH);
+  expect(() => parseImport(csvPath, {}, { db })).toThrow(/Unable to detect/);
+});
+
+test('parseImport throws ValidationError when file does not exist', async () => {
+  const { parseImport } = await import('../../src/services/importers');
+  const { db } = getDb(DB_PATH);
+  expect(() => parseImport(join(tmp, 'nonexistent.csv'), {}, { db })).toThrow(/File not found/);
+});

--- a/tests/unit/importer-dedupe.test.ts
+++ b/tests/unit/importer-dedupe.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from 'bun:test';
+import { isDuplicate, levenshtein } from '../../src/services/importers/dedupe';
+
+const baseExisting = [
+  {
+    id: 'csv_existing_1',
+    date: new Date(Date.UTC(2026, 3, 15)),
+    amount: -12.5,
+    description: 'TESCO STORES 1234',
+  },
+];
+
+describe('strict dedupe', () => {
+  test('matches when date, amount, and normalized description are identical', () => {
+    expect(
+      isDuplicate(
+        {
+          id: 'new',
+          date: new Date(Date.UTC(2026, 3, 15)),
+          amount: -12.5,
+          description: '  Tesco Stores 1234  ',
+        },
+        baseExisting,
+        'strict',
+      ),
+    ).toBe(true);
+  });
+
+  test('does NOT match when description has a small typo', () => {
+    expect(
+      isDuplicate(
+        {
+          id: 'new',
+          date: new Date(Date.UTC(2026, 3, 15)),
+          amount: -12.5,
+          description: 'TESCO STORES 1235',
+        },
+        baseExisting,
+        'strict',
+      ),
+    ).toBe(false);
+  });
+
+  test('does NOT match when amount differs', () => {
+    expect(
+      isDuplicate(
+        {
+          id: 'new',
+          date: new Date(Date.UTC(2026, 3, 15)),
+          amount: -13.5,
+          description: 'TESCO STORES 1234',
+        },
+        baseExisting,
+        'strict',
+      ),
+    ).toBe(false);
+  });
+
+  test('does NOT match when date differs', () => {
+    expect(
+      isDuplicate(
+        {
+          id: 'new',
+          date: new Date(Date.UTC(2026, 3, 16)),
+          amount: -12.5,
+          description: 'TESCO STORES 1234',
+        },
+        baseExisting,
+        'strict',
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('loose dedupe', () => {
+  test('matches when description differs by Levenshtein < 3', () => {
+    expect(
+      isDuplicate(
+        {
+          id: 'new',
+          date: new Date(Date.UTC(2026, 3, 15)),
+          amount: -12.5,
+          description: 'TESCO STORES 1235', // 1 char diff
+        },
+        baseExisting,
+        'loose',
+      ),
+    ).toBe(true);
+  });
+
+  test('matches across adjacent days within 1 day window', () => {
+    expect(
+      isDuplicate(
+        {
+          id: 'new',
+          date: new Date(Date.UTC(2026, 3, 16)),
+          amount: -12.5,
+          description: 'TESCO STORES 1234',
+        },
+        baseExisting,
+        'loose',
+      ),
+    ).toBe(true);
+  });
+
+  test('matches via substring', () => {
+    expect(
+      isDuplicate(
+        {
+          id: 'new',
+          date: new Date(Date.UTC(2026, 3, 15)),
+          amount: -12.5,
+          description: 'TESCO',
+        },
+        baseExisting,
+        'loose',
+      ),
+    ).toBe(true);
+  });
+
+  test('does NOT match when description very different', () => {
+    expect(
+      isDuplicate(
+        {
+          id: 'new',
+          date: new Date(Date.UTC(2026, 3, 15)),
+          amount: -12.5,
+          description: 'AMAZON UK',
+        },
+        baseExisting,
+        'loose',
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('levenshtein', () => {
+  test('identical', () => expect(levenshtein('abc', 'abc')).toBe(0));
+  test('one substitution', () => expect(levenshtein('abc', 'abd')).toBe(1));
+  test('one insertion', () => expect(levenshtein('abc', 'abcd')).toBe(1));
+  test('empty strings', () => {
+    expect(levenshtein('', '')).toBe(0);
+    expect(levenshtein('', 'abc')).toBe(3);
+    expect(levenshtein('abc', '')).toBe(3);
+  });
+  test('classic kitten/sitting -> 3', () => {
+    expect(levenshtein('kitten', 'sitting')).toBe(3);
+  });
+});

--- a/tests/unit/importer-dedupe.test.ts
+++ b/tests/unit/importer-dedupe.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test';
-import { isDuplicate, levenshtein } from '../../src/services/importers/dedupe';
+import {
+  buildLooseBuckets,
+  isDuplicate,
+  isDuplicateLoose,
+  levenshtein,
+} from '../../src/services/importers/dedupe';
 
 const baseExisting = [
   {
@@ -129,6 +134,139 @@ describe('loose dedupe', () => {
         },
         baseExisting,
         'loose',
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('loose dedupe via bucket index', () => {
+  // Verifies the O(parsed + window) average-case fast path: a candidate whose
+  // (date, amount) bucket is empty must return false WITHOUT touching
+  // Levenshtein. We instrument by giving the bucket builder an `existing` set
+  // that intentionally has no bucket overlap with the candidate.
+  test('bucket-miss returns false without scanning the wider window', () => {
+    const existing = [
+      {
+        id: 'csv_existing_1',
+        date: new Date(Date.UTC(2026, 3, 15)),
+        amount: -12.5,
+        description: 'TESCO STORES 1234',
+      },
+      {
+        id: 'csv_existing_2',
+        date: new Date(Date.UTC(2026, 3, 16)),
+        amount: -12.5,
+        description: 'TESCO STORES 1234',
+      },
+    ];
+    const index = buildLooseBuckets(existing);
+
+    // Same amount, but date is 10 days away from any existing row -> bucket
+    // miss. The fuzzy substring/Levenshtein check must NOT fire.
+    expect(
+      isDuplicateLoose(
+        {
+          id: 'new',
+          date: new Date(Date.UTC(2026, 3, 25)),
+          amount: -12.5,
+          description: 'TESCO STORES 1234',
+        },
+        index,
+      ),
+    ).toBe(false);
+  });
+
+  test('bucket hit applies fuzzy match (Levenshtein < 3)', () => {
+    const existing = [
+      {
+        id: 'csv_existing_1',
+        date: new Date(Date.UTC(2026, 3, 15)),
+        amount: -12.5,
+        description: 'TESCO STORES 1234',
+      },
+    ];
+    const index = buildLooseBuckets(existing);
+
+    // Same date + amount, description differs by one char -> bucket hit, fuzzy
+    // match succeeds.
+    expect(
+      isDuplicateLoose(
+        {
+          id: 'new',
+          date: new Date(Date.UTC(2026, 3, 15)),
+          amount: -12.5,
+          description: 'TESCO STORES 1235',
+        },
+        index,
+      ),
+    ).toBe(true);
+  });
+
+  test('matches across adjacent day via bucket index', () => {
+    const existing = [
+      {
+        id: 'csv_existing_1',
+        date: new Date(Date.UTC(2026, 3, 15)),
+        amount: -12.5,
+        description: 'TESCO STORES 1234',
+      },
+    ];
+    const index = buildLooseBuckets(existing);
+    expect(
+      isDuplicateLoose(
+        {
+          id: 'new',
+          date: new Date(Date.UTC(2026, 3, 16)),
+          amount: -12.5,
+          description: 'TESCO STORES 1234',
+        },
+        index,
+      ),
+    ).toBe(true);
+  });
+
+  test('id-equality short-circuit', () => {
+    const existing = [
+      {
+        id: 'csv_existing_1',
+        date: new Date(Date.UTC(2026, 3, 15)),
+        amount: -12.5,
+        description: 'TESCO STORES 1234',
+      },
+    ];
+    const index = buildLooseBuckets(existing);
+    expect(
+      isDuplicateLoose(
+        {
+          id: 'csv_existing_1',
+          date: new Date(Date.UTC(2030, 0, 1)),
+          amount: 999,
+          description: 'completely different',
+        },
+        index,
+      ),
+    ).toBe(true);
+  });
+
+  test('amount mismatch in same day -> bucket miss, no fuzzy work', () => {
+    const existing = [
+      {
+        id: 'csv_existing_1',
+        date: new Date(Date.UTC(2026, 3, 15)),
+        amount: -12.5,
+        description: 'TESCO STORES 1234',
+      },
+    ];
+    const index = buildLooseBuckets(existing);
+    expect(
+      isDuplicateLoose(
+        {
+          id: 'new',
+          date: new Date(Date.UTC(2026, 3, 15)),
+          amount: -99.99,
+          description: 'TESCO STORES 1234',
+        },
+        index,
       ),
     ).toBe(false);
   });

--- a/tests/unit/importers/dedupe-strict-index.test.ts
+++ b/tests/unit/importers/dedupe-strict-index.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  buildStrictIndex,
+  isDuplicate,
+  isDuplicateStrict,
+} from '../../../src/services/importers/dedupe';
+
+const existing = [
+  {
+    id: 'csv_existing_1',
+    date: new Date(Date.UTC(2026, 3, 15)),
+    amount: -12.5,
+    description: 'TESCO STORES 1234',
+  },
+  {
+    id: 'csv_existing_2',
+    date: new Date(Date.UTC(2026, 3, 16)),
+    amount: 25,
+    description: 'REFUND',
+  },
+];
+
+describe('strict dedupe via hash index', () => {
+  const index = buildStrictIndex(existing);
+
+  test('id-equality short-circuit', () => {
+    expect(
+      isDuplicateStrict(
+        {
+          id: 'csv_existing_1',
+          date: new Date(Date.UTC(2030, 0, 1)),
+          amount: 999,
+          description: 'completely different',
+        },
+        index,
+      ),
+    ).toBe(true);
+  });
+
+  test('matches by (date, amount, normalized description)', () => {
+    expect(
+      isDuplicateStrict(
+        {
+          id: 'new',
+          date: new Date(Date.UTC(2026, 3, 15)),
+          amount: -12.5,
+          description: '  Tesco Stores 1234  ',
+        },
+        index,
+      ),
+    ).toBe(true);
+  });
+
+  test('does NOT match across days', () => {
+    expect(
+      isDuplicateStrict(
+        {
+          id: 'new',
+          date: new Date(Date.UTC(2026, 3, 17)),
+          amount: -12.5,
+          description: 'TESCO STORES 1234',
+        },
+        index,
+      ),
+    ).toBe(false);
+  });
+
+  test('does NOT match when amount differs', () => {
+    expect(
+      isDuplicateStrict(
+        {
+          id: 'new',
+          date: new Date(Date.UTC(2026, 3, 15)),
+          amount: -13.5,
+          description: 'TESCO STORES 1234',
+        },
+        index,
+      ),
+    ).toBe(false);
+  });
+
+  test('agrees with the existing isDuplicate strict path', () => {
+    const cand = {
+      id: 'new',
+      date: new Date(Date.UTC(2026, 3, 15)),
+      amount: -12.5,
+      description: 'TESCO STORES 1234',
+    };
+    expect(isDuplicateStrict(cand, index)).toBe(isDuplicate(cand, existing, 'strict'));
+  });
+});

--- a/tests/unit/importers/lloyds.test.ts
+++ b/tests/unit/importers/lloyds.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from 'bun:test';
+import { detectFormat } from '../../../src/services/importers';
+import { parseLloyds } from '../../../src/services/importers/lloyds';
+
+const FIXTURE = [
+  'Transaction Date,Transaction Type,Sort Code,Account Number,Transaction Description,Debit Amount,Credit Amount,Balance',
+  '15/04/2026,DEB,30-99-50,12345678,TESCO STORES,12.50,,1234.56',
+  '16/04/2026,FPI,30-99-50,12345678,SALARY ACME LTD,,2500.00,3734.56',
+  '17/04/2026,DEB,30-99-50,12345678,"AMAZON, UK",45.99,,3688.57',
+].join('\n');
+
+test('detects Lloyds from header', () => {
+  expect(detectFormat(FIXTURE.split('\n')[0] as string)).toBe('lloyds');
+});
+
+test('parses Lloyds rows: debit negative, credit positive, quoted commas', () => {
+  const rows = parseLloyds(FIXTURE);
+  expect(rows.length).toBe(3);
+
+  expect(rows[0]?.amount).toBe(-12.5);
+  expect(rows[0]?.description).toBe('TESCO STORES');
+  expect(rows[0]?.currency).toBe('GBP');
+  expect(rows[0]?.date.toISOString().slice(0, 10)).toBe('2026-04-15');
+
+  expect(rows[1]?.amount).toBe(2500);
+  expect(rows[1]?.description).toBe('SALARY ACME LTD');
+
+  expect(rows[2]?.amount).toBe(-45.99);
+  expect(rows[2]?.description).toBe('AMAZON, UK');
+});
+
+test('Lloyds parser tolerates UTF-8 BOM', () => {
+  const withBom = `\ufeff${FIXTURE}`;
+  const rows = parseLloyds(withBom);
+  expect(rows.length).toBe(3);
+});

--- a/tests/unit/importers/natwest.test.ts
+++ b/tests/unit/importers/natwest.test.ts
@@ -12,6 +12,14 @@ test('detects NatWest from header', () => {
   expect(detectFormat(FIXTURE.split('\n')[0] as string)).toBe('natwest');
 });
 
+test('does NOT misdetect a generic ledger header as NatWest', () => {
+  // Pre-fix, the signature triggered on date+account name+account number+value.
+  // A generic export with those columns but missing Type/Description should not
+  // match: the new signature requires both 'type' and 'description' headers.
+  expect(detectFormat('date,account name,account number,value')).not.toBe('natwest');
+  expect(detectFormat('date,description,account name,account number,value')).not.toBe('natwest');
+});
+
 test('parses NatWest rows preserving signed values', () => {
   const rows = parseNatwest(FIXTURE);
   expect(rows.length).toBe(2);

--- a/tests/unit/importers/natwest.test.ts
+++ b/tests/unit/importers/natwest.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'bun:test';
+import { detectFormat } from '../../../src/services/importers';
+import { parseNatwest } from '../../../src/services/importers/natwest';
+
+const FIXTURE = [
+  'Date,Type,Description,Value,Balance,Account Name,Account Number',
+  '15/04/2026,POS,"PRET A MANGER",-4.50,1000.00,MAIN,12345678',
+  '16/04/2026,BAC,"REFUND",10.00,1010.00,MAIN,12345678',
+].join('\n');
+
+test('detects NatWest from header', () => {
+  expect(detectFormat(FIXTURE.split('\n')[0] as string)).toBe('natwest');
+});
+
+test('parses NatWest rows preserving signed values', () => {
+  const rows = parseNatwest(FIXTURE);
+  expect(rows.length).toBe(2);
+
+  expect(rows[0]?.amount).toBe(-4.5);
+  expect(rows[0]?.description).toBe('PRET A MANGER');
+  expect(rows[0]?.currency).toBe('GBP');
+  expect(rows[0]?.date.toISOString().slice(0, 10)).toBe('2026-04-15');
+
+  expect(rows[1]?.amount).toBe(10);
+  expect(rows[1]?.description).toBe('REFUND');
+});

--- a/tests/unit/importers/revolut.test.ts
+++ b/tests/unit/importers/revolut.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'bun:test';
+import { detectFormat } from '../../../src/services/importers';
+import { parseRevolut } from '../../../src/services/importers/revolut';
+
+const FIXTURE = [
+  'Type,Product,Started Date,Completed Date,Description,Amount,Fee,Currency,State,Balance',
+  'CARD_PAYMENT,Current,2026-04-15 09:00:00,2026-04-15 09:01:00,Tesco,-12.50,0.00,GBP,COMPLETED,500.00',
+  'CARD_PAYMENT,Current,2026-04-16 12:00:00,2026-04-16 12:00:30,FX Coffee,-3.00,0.20,EUR,COMPLETED,496.80',
+  'TOPUP,Current,2026-04-17 08:00:00,2026-04-17 08:00:00,Top-Up,100.00,0.00,GBP,COMPLETED,596.80',
+  'CARD_PAYMENT,Current,2026-04-18 10:00:00,,Pending Coffee,-5.00,0.00,GBP,PENDING,591.80',
+].join('\n');
+
+test('detects Revolut from header', () => {
+  expect(detectFormat(FIXTURE.split('\n')[0] as string)).toBe('revolut');
+});
+
+test('parses Revolut rows: skips non-COMPLETED, applies fee, preserves currency', () => {
+  const rows = parseRevolut(FIXTURE);
+  // PENDING row is skipped.
+  expect(rows.length).toBe(3);
+
+  expect(rows[0]?.amount).toBe(-12.5);
+  expect(rows[0]?.currency).toBe('GBP');
+  expect(rows[0]?.description).toBe('Tesco');
+
+  // Net = -3.00 - 0.20 = -3.20 (fee subtracted from outflow).
+  expect(rows[1]?.amount).toBeCloseTo(-3.2, 5);
+  expect(rows[1]?.currency).toBe('EUR');
+
+  expect(rows[2]?.amount).toBe(100);
+  expect(rows[2]?.currency).toBe('GBP');
+});

--- a/tests/unit/importers/uk-validation.test.ts
+++ b/tests/unit/importers/uk-validation.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test';
+import { ValidationError } from '../../../src/lib/errors';
+import { EMPTY_DESCRIPTION, parseBarclays } from '../../../src/services/importers/barclays';
+import { parseHsbc } from '../../../src/services/importers/hsbc';
+import { parseFloatSafe, parseUkDate } from '../../../src/services/importers/uk-date';
+
+describe('parseUkDate (shared)', () => {
+  test('parses dd/MM/yyyy', () => {
+    const d = parseUkDate('15/04/2026', 'Test');
+    expect(d.toISOString().slice(0, 10)).toBe('2026-04-15');
+  });
+
+  test('rejects out-of-range day (32/01/2026)', () => {
+    expect(() => parseUkDate('32/01/2026', 'Test')).toThrow(ValidationError);
+  });
+
+  test('rejects out-of-range month (15/13/2026)', () => {
+    expect(() => parseUkDate('15/13/2026', 'Test')).toThrow(ValidationError);
+  });
+
+  test('rejects 30/02/2026 (Feb has no 30th)', () => {
+    expect(() => parseUkDate('30/02/2026', 'Test')).toThrow(ValidationError);
+  });
+
+  test('rejects garbage', () => {
+    expect(() => parseUkDate('not-a-date', 'Test')).toThrow(ValidationError);
+  });
+});
+
+describe('parseFloatSafe (shared)', () => {
+  test('returns 0 for empty string', () => {
+    expect(parseFloatSafe('', 'Test')).toBe(0);
+    expect(parseFloatSafe('   ', 'Test')).toBe(0);
+  });
+
+  test('parses signed decimals and strips £/commas', () => {
+    expect(parseFloatSafe('£1,234.56', 'Test')).toBe(1234.56);
+    expect(parseFloatSafe('-12.50', 'Test')).toBe(-12.5);
+  });
+
+  test('throws ValidationError for non-empty unparseable input', () => {
+    expect(() => parseFloatSafe('not a number', 'Test')).toThrow(ValidationError);
+    expect(() => parseFloatSafe('12abc', 'Test')).toThrow(ValidationError);
+  });
+
+  test('error message includes row number when provided', () => {
+    try {
+      parseFloatSafe('xyz', 'Bank', 42);
+      throw new Error('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ValidationError);
+      expect((e as Error).message).toContain('row 42');
+    }
+  });
+});
+
+describe('Barclays parser', () => {
+  test('uses synthetic description marker when memo and subcategory are empty', () => {
+    const csv = ['Number,Date,Account,Amount,Subcategory,Memo', '1,15/04/2026,Acct,-12.50,,'].join(
+      '\n',
+    );
+    const rows = parseBarclays(csv);
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.description).toBe(EMPTY_DESCRIPTION);
+  });
+
+  test('throws on invalid date', () => {
+    const csv = [
+      'Number,Date,Account,Amount,Subcategory,Memo',
+      '1,32/13/2026,Acct,-12.50,,Tesco',
+    ].join('\n');
+    expect(() => parseBarclays(csv)).toThrow(ValidationError);
+  });
+
+  test('throws on unparseable amount', () => {
+    const csv = [
+      'Number,Date,Account,Amount,Subcategory,Memo',
+      '1,15/04/2026,Acct,nope,,Tesco',
+    ].join('\n');
+    expect(() => parseBarclays(csv)).toThrow(ValidationError);
+  });
+});
+
+describe('HSBC parser', () => {
+  test('throws on invalid date', () => {
+    const csv = ['Date,Description,Amount,Balance', '30/02/2026,Tesco,-12.50,100'].join('\n');
+    expect(() => parseHsbc(csv)).toThrow(ValidationError);
+  });
+
+  test('throws on unparseable amount', () => {
+    const csv = ['Date,Description,Amount,Balance', '15/04/2026,Tesco,nope,100'].join('\n');
+    expect(() => parseHsbc(csv)).toThrow(ValidationError);
+  });
+});


### PR DESCRIPTION
Closes #8.

## Summary
- **`services/importers/index.ts`** — RFC-4180-light CSV parser, header-signature autodetection, `parseImport` orchestrator with atomic `db.transaction` insert, dry-run, BOM/CRLF handling.
- **`services/importers/{lloyds,natwest,revolut}.ts`** — spec-validated parsers (Lloyds debit/credit columns, NatWest signed Value, Revolut multi-currency COMPLETED-only fee-net).
- **`services/importers/{hsbc,barclays,santander}.ts`** — best-effort parsers based on commonly-published export formats; carry `// TODO: validate against real export` markers.
- **`services/importers/dedupe.ts`** — strict (exact `(date,amount,description)` hash) and loose (fuzzy on description via inline Levenshtein < 3 or normalized substring) strategies.
- **`commands/import`** — positional `<file>`, `--format`, `--account` (creates virtual `manual` account when omitted, `is_manual=true`), `--dry-run`, `--dedupe-strategy strict|loose` (default strict).
- **`commands/export`** — streams CSV/JSON to stdout. `--since`, `--until`, `--category`. Includes derived `source` field per PRD §4.8.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun run check` clean
- [x] `bun test` — **38 new tests pass**
- [x] `bun run src/cli.ts import --help` and `export --help` render
- [x] Smoke: temp HOME → init → dry-run import → real import → dedupe re-import (no-op) → CSV round-trip → JSON round-trip — all green

## Spec validation status
| Bank | Status | Notes |
|---|---|---|
| Lloyds | ✅ spec-validated | dd/MM/yyyy, Debit/Credit columns |
| NatWest | ✅ spec-validated | Signed Value column |
| Revolut | ✅ spec-validated | Multi-currency, fee-net |
| HSBC | ⚠️ best-effort | TODO marker for real-export validation |
| Barclays | ⚠️ best-effort | TODO marker |
| Santander | ⚠️ best-effort | TODO marker |

## Untouched files (per parallel-agent contract)
`src/cli.ts`, `src/commands/index.ts`, `src/db/schema.ts`, `package.json`, `src/lib/{dates,format}.ts` (Phase 3 owns), configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)