### PR TITLE
feat(audit): append-only audit log for security-significant events

### DIFF
--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -14,6 +14,7 @@ import { defineCommand } from 'citty';
 import consola from 'consola';
 import picocolors from 'picocolors';
 import { setBudget } from '../db/queries/budgets';
+import { appendAuditEvent } from '../lib/audit';
 import { loadConfig } from '../lib/config';
 import { FerretError, ValidationError } from '../lib/errors';
 import { formatJson } from '../lib/format';
@@ -116,6 +117,15 @@ export default defineCommand({
           },
         });
       }
+
+      // Audit: one event per ask invocation. Per issue #48 the question
+      // text, answer text, and tool inputs/outputs are all omitted — we
+      // record only the counts that matter for rate / compliance
+      // reporting. Fires regardless of output mode.
+      appendAuditEvent('ask.invoked', {
+        tool_calls_count: collected.toolsUsed.length,
+        iterations: collected.iterations,
+      });
 
       // Deduplicate proposals by category — Claude may emit the same
       // category twice across iterations (e.g. revising an amount). Keep

--- a/src/commands/budget.ts
+++ b/src/commands/budget.ts
@@ -15,6 +15,7 @@ import {
   removeBudget,
   setBudget,
 } from '../db/queries/budgets';
+import { appendAuditEvent } from '../lib/audit';
 import { ValidationError } from '../lib/errors';
 import { renderProgressBar } from '../lib/progress-bar';
 
@@ -151,6 +152,9 @@ export default defineCommand({
         const amount = parseAmount(args.amount);
         const currency = defaultCurrency();
         const saved = setBudget(category, amount, currency);
+        // Per issue #48, budget events log the category only. The amount
+        // is deliberately omitted — it is PII-adjacent spending detail.
+        appendAuditEvent('budget.set', { category: saved.category });
         process.stdout.write(
           `set budget: ${saved.category} ${fmtMoney(saved.monthlyAmount, saved.currency)} / month\n`,
         );
@@ -167,6 +171,7 @@ export default defineCommand({
         if (!removed) {
           throw new ValidationError(`No budget set for category: ${category}`);
         }
+        appendAuditEvent('budget.removed', { category });
         process.stdout.write(`removed budget: ${category}\n`);
       },
     }),

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from 'citty';
+import { appendAuditEvent } from '../lib/audit';
 import {
   configPath,
   ferretHome,
@@ -44,6 +45,10 @@ export default defineCommand({
         const cfg = loadConfig();
         const next = setConfigValue(cfg, key, value);
         writeConfig(next);
+        // Issue #48 explicitly says "key only, value omitted" — the key
+        // surface is safe (it's documented in the PRD), but arbitrary
+        // user-supplied values could be anything.
+        appendAuditEvent('config.changed', { key });
         process.stdout.write(`set ${key} = ${value}\n`);
       },
     }),

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from 'citty';
+import { appendAuditEvent } from '../lib/audit';
 import { ValidationError } from '../lib/errors';
 import {
   BANK_FORMATS,
@@ -64,6 +65,16 @@ export default defineCommand({
     process.stdout.write(
       `${banner}format=${result.format} account=${result.accountId} parsed=${result.parsed} inserted=${result.inserted} duplicates=${result.duplicates}\n`,
     );
+
+    // Audit trail: completion is only recorded for real runs (not dry-run).
+    // Per issue #48 we log counts only — never the filename / absolute path.
+    if (!result.dryRun) {
+      appendAuditEvent('import.completed', {
+        format: result.format,
+        rows_added: result.inserted,
+        rows_duplicate: result.duplicates,
+      });
+    }
 
     if (result.dryRun && result.preview.length > 0) {
       process.stdout.write('preview:\n');

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -12,6 +12,7 @@ import { defineCommand } from 'citty';
 import consola from 'consola';
 import { getDb } from '../db/client';
 import { accounts, connections } from '../db/schema';
+import { appendAuditEvent } from '../lib/audit';
 import { AuthError, DataIntegrityError, ValidationError } from '../lib/errors';
 import { TRUELAYER_CLIENT_ID, TRUELAYER_CLIENT_SECRET, resolveSecret } from '../lib/secrets';
 import { accountNames, setToken } from '../services/keychain';
@@ -241,6 +242,16 @@ export default defineCommand({
         consola.warn(`Skipped card ${c.account_id.slice(0, 8)}…: ${(err as Error).message}`);
       }
     }
+
+    // Audit trail — provider id + connection id are not secrets, and the
+    // discovered-count helps reconcile later sync runs. No tokens or
+    // account numbers are logged.
+    appendAuditEvent('connection.linked', {
+      connection_id: connectionId,
+      provider_id: meResult.provider.provider_id,
+      accounts_discovered: accountRows.length,
+      cards_discovered: cardRows.length,
+    });
 
     consola.success(
       `Connected: ${meResult.provider.display_name} (expires ${connExpiresAt.toISOString().slice(0, 10)})`,

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -16,6 +16,7 @@ import { eq } from 'drizzle-orm';
 import { getDb } from '../db/client';
 import { categoryExists, getNextRulePriority, getRules } from '../db/queries/categorize';
 import { rules } from '../db/schema';
+import { appendAuditEvent } from '../lib/audit';
 import { ValidationError } from '../lib/errors';
 import { formatTable } from '../lib/format';
 
@@ -103,6 +104,12 @@ export default defineCommand({
             createdAt: new Date(),
           })
           .run();
+        appendAuditEvent('rule.added', {
+          rule_id: id,
+          field,
+          category,
+          priority,
+        });
         consola.success(
           `added rule ${id} (priority ${priority}): /${pattern}/i on ${field} -> ${category}`,
         );
@@ -121,6 +128,7 @@ export default defineCommand({
           throw new ValidationError(`No rule found with id "${id}".`);
         }
         db.delete(rules).where(eq(rules.id, id)).run();
+        appendAuditEvent('rule.removed', { rule_id: id });
         consola.success(`removed rule ${id}`);
       },
     }),

--- a/src/commands/unlink.ts
+++ b/src/commands/unlink.ts
@@ -13,6 +13,7 @@ import consola from 'consola';
 import { eq, inArray, sql } from 'drizzle-orm';
 import { getDb } from '../db/client';
 import { accounts, connections, syncLog, transactions } from '../db/schema';
+import { appendAuditEvent } from '../lib/audit';
 import { ValidationError } from '../lib/errors';
 import { deleteAllForConnection } from '../services/keychain';
 
@@ -40,6 +41,12 @@ export default defineCommand({
     });
 
     db.update(connections).set({ status: 'revoked' }).where(eq(connections.id, connectionId)).run();
+
+    appendAuditEvent('connection.unlinked', {
+      connection_id: connectionId,
+      provider_id: conn.providerId,
+      keychain_entries_removed: removed,
+    });
 
     consola.success(
       `Unlinked ${conn.providerName} (${connectionId}). Removed ${removed} keychain entr${removed === 1 ? 'y' : 'ies'}; transaction history retained.`,

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,0 +1,228 @@
+// Append-only local audit log for security-significant events (PRD §9.3 +
+// epic #36 — ISO 27001 A.12 / SOC 2 CC7).
+//
+// Contract:
+//   - File lives at `${FERRET_HOME}/audit.log`, JSONL (one event per line).
+//   - Permissions: 0600 (owner read/write only). Preserved across rotation.
+//   - Atomic append: open fd with O_APPEND|O_CREAT|O_WRONLY, single writeSync
+//     of `<json>\n`, close. No buffering, no partial lines on crash.
+//   - Rotation: when the file reaches ROTATE_BYTES it is renamed to
+//     `audit.log.1` (single rollover). A fresh 0600 file is created on the
+//     next append.
+//   - Redaction: every field whose key matches SECRET_KEY_PATTERN is replaced
+//     with '[REDACTED]' before serialisation, recursively. This is the
+//     last-line safety net — callers should still avoid passing raw secrets.
+//
+// The module MUST NOT pull in dependencies beyond node built-ins. No
+// dynamic imports, no side-effect imports — tests rely on this file being
+// cheap to import.
+
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  constants as fsConstants,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/** Event names emitted by Ferret. Keep in sync with issue #48. */
+export type AuditEventType =
+  | 'connection.linked'
+  | 'connection.unlinked'
+  | 'connection.reauth_marked'
+  | 'config.changed'
+  | 'rule.added'
+  | 'rule.removed'
+  | 'budget.set'
+  | 'budget.removed'
+  | 'sync.started'
+  | 'sync.completed'
+  | 'sync.failed'
+  | 'import.completed'
+  | 'ask.invoked';
+
+/** 5 MiB rollover threshold per issue #48. */
+export const ROTATE_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Keys whose values are suppressed before serialisation. Match against the
+ * key name only (case-insensitive) — we never inspect values, since a value
+ * that *looks* like a token (long opaque string) may legitimately be e.g. a
+ * connection id. Callers must label their secrets with one of these names.
+ */
+const SECRET_KEY_PATTERN = /(token|secret|api_?key|password|refresh|authorization)/i;
+
+/** Sentinel the redactor substitutes in for suppressed values. */
+export const REDACTED = '[REDACTED]';
+
+/**
+ * Mirror of `getFerretHome()` from `src/db/client.ts` — computed lazily so
+ * tests that override `HOME` via `mktemp` pick up the new value per-call.
+ * Do NOT cache at module scope.
+ */
+function getFerretHome(): string {
+  return join(process.env.HOME ?? homedir(), '.ferret');
+}
+
+/** Absolute path to the current audit log. */
+export function getAuditLogPath(): string {
+  return join(getFerretHome(), 'audit.log');
+}
+
+/** Absolute path to the rotated (previous) audit log, if any. */
+export function getAuditLogRotatedPath(): string {
+  return `${getAuditLogPath()}.1`;
+}
+
+/**
+ * Walk an arbitrary object tree and replace any value whose key matches
+ * {@link SECRET_KEY_PATTERN} with {@link REDACTED}. Returns a new object —
+ * the input is not mutated. Non-plain-object values (arrays, Dates,
+ * primitives) are passed through unchanged.
+ *
+ * Limited depth (16) to guarantee termination on self-referential inputs;
+ * audit payloads are shallow in practice.
+ */
+export function redactSecrets(input: Record<string, unknown>, depth = 0): Record<string, unknown> {
+  if (depth > 16) return input;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(input)) {
+    if (SECRET_KEY_PATTERN.test(k)) {
+      out[k] = REDACTED;
+      continue;
+    }
+    if (v && typeof v === 'object' && !Array.isArray(v) && !(v instanceof Date)) {
+      out[k] = redactSecrets(v as Record<string, unknown>, depth + 1);
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+/**
+ * Rotate the log if it exceeds {@link ROTATE_BYTES}. Single rollover: if a
+ * previous `audit.log.1` exists it is overwritten. Best-effort — errors
+ * swallowed so a rotation failure never blocks a caller.
+ */
+function maybeRotate(path: string): void {
+  try {
+    const st = statSync(path);
+    if (st.size < ROTATE_BYTES) return;
+    const rotated = `${path}.1`;
+    renameSync(path, rotated);
+    // chmod the rotated file explicitly in case the rename lands on a FS
+    // that reset the mode bits. Swallow chmod errors — on Windows this
+    // isn't meaningful.
+    try {
+      chmodSync(rotated, 0o600);
+    } catch {
+      /* best effort */
+    }
+  } catch {
+    // statSync fails if the file doesn't exist yet — that's the common
+    // first-call case. Nothing to do.
+  }
+}
+
+/** Ensure `${FERRET_HOME}` exists with 0700 before touching the log file. */
+function ensureHome(): void {
+  const home = getFerretHome();
+  if (!existsSync(home)) {
+    mkdirSync(home, { recursive: true, mode: 0o700 });
+  }
+}
+
+/**
+ * Append a single audit event. The wire shape is:
+ *
+ *   {"ts":"<ISO>","type":"<event>", ...redactedFields}
+ *
+ * Fields named like secrets (see {@link SECRET_KEY_PATTERN}) are replaced
+ * with {@link REDACTED} before the line is written.
+ *
+ * Never throws — audit logging must not interrupt the primary command
+ * flow. Any failure is swallowed silently (by design; observability of
+ * the audit pipeline itself is out of scope for v0.1).
+ */
+export function appendAuditEvent(type: AuditEventType, fields: Record<string, unknown> = {}): void {
+  try {
+    ensureHome();
+    const path = getAuditLogPath();
+    maybeRotate(path);
+
+    const payload = {
+      ts: new Date().toISOString(),
+      type,
+      ...redactSecrets(fields),
+    };
+
+    // JSON.stringify collapses Date → ISO string naturally; the payload
+    // cannot contain newlines in unescaped form because stringify escapes
+    // them, so the `\n` terminator is unambiguous.
+    const line = `${JSON.stringify(payload)}\n`;
+
+    const fd = openSync(
+      path,
+      // eslint-disable-next-line no-bitwise -- standard POSIX flag combination
+      fsConstants.O_APPEND | fsConstants.O_CREAT | fsConstants.O_WRONLY,
+      0o600,
+    );
+    try {
+      writeSync(fd, line);
+    } finally {
+      closeSync(fd);
+    }
+
+    // On some filesystems O_CREAT honours the umask, so the file may end
+    // up 0644. chmod explicitly to guarantee 0600. Ignore failures.
+    try {
+      chmodSync(path, 0o600);
+    } catch {
+      /* best effort — e.g. Windows */
+    }
+  } catch {
+    // Swallow: audit logging must never break a command.
+  }
+}
+
+/**
+ * Read the last `n` lines of the audit log. Returns an empty array if the
+ * file does not exist. Lines that fail to parse as JSON are skipped (they
+ * shouldn't happen — we only ever append well-formed lines — but a partial
+ * write from a crash shouldn't poison the tail reader).
+ *
+ * Exposed primarily for tests and a future `ferret audit` command.
+ */
+export function tailAuditLog(n: number): Array<Record<string, unknown>> {
+  const path = getAuditLogPath();
+  if (!existsSync(path)) return [];
+  const raw = readFileSync(path, 'utf-8');
+  const lines = raw.split('\n').filter((l) => l.length > 0);
+  const tail = n >= lines.length ? lines : lines.slice(lines.length - n);
+  const out: Array<Record<string, unknown>> = [];
+  for (const l of tail) {
+    try {
+      out.push(JSON.parse(l) as Record<string, unknown>);
+    } catch {
+      // ignore malformed line
+    }
+  }
+  return out;
+}
+
+/**
+ * Manually invoke the rotation check. Exposed for tests; the normal path
+ * rotates lazily inside {@link appendAuditEvent}.
+ */
+export function rotateIfNeeded(): void {
+  const path = getAuditLogPath();
+  maybeRotate(path);
+}

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -22,15 +22,16 @@ import {
   closeSync,
   existsSync,
   constants as fsConstants,
+  fstatSync,
   mkdirSync,
   openSync,
   readFileSync,
+  readSync,
   renameSync,
-  statSync,
   writeSync,
 } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { getFerretHome } from '../db/client';
 
 /** Event names emitted by Ferret. Keep in sync with issue #48. */
 export type AuditEventType =
@@ -61,15 +62,6 @@ const SECRET_KEY_PATTERN = /(token|secret|api_?key|password|refresh|authorizatio
 
 /** Sentinel the redactor substitutes in for suppressed values. */
 export const REDACTED = '[REDACTED]';
-
-/**
- * Mirror of `getFerretHome()` from `src/db/client.ts` — computed lazily so
- * tests that override `HOME` via `mktemp` pick up the new value per-call.
- * Do NOT cache at module scope.
- */
-function getFerretHome(): string {
-  return join(process.env.HOME ?? homedir(), '.ferret');
-}
 
 /** Absolute path to the current audit log. */
 export function getAuditLogPath(): string {
@@ -108,14 +100,14 @@ export function redactSecrets(input: Record<string, unknown>, depth = 0): Record
 }
 
 /**
- * Rotate the log if it exceeds {@link ROTATE_BYTES}. Single rollover: if a
- * previous `audit.log.1` exists it is overwritten. Best-effort — errors
- * swallowed so a rotation failure never blocks a caller.
+ * Rotate `path` to `${path}.1`, overwriting any previous rotated file. Used
+ * both by the inline "check size on the same fd" path in
+ * {@link appendAuditEvent} and by the test-only {@link rotateIfNeeded} entry
+ * point. Best-effort — errors swallowed so a rotation failure never blocks
+ * a caller.
  */
-function maybeRotate(path: string): void {
+function rotateNow(path: string): void {
   try {
-    const st = statSync(path);
-    if (st.size < ROTATE_BYTES) return;
     const rotated = `${path}.1`;
     renameSync(path, rotated);
     // chmod the rotated file explicitly in case the rename lands on a FS
@@ -127,8 +119,21 @@ function maybeRotate(path: string): void {
       /* best effort */
     }
   } catch {
-    // statSync fails if the file doesn't exist yet — that's the common
+    // rename fails if the file doesn't exist yet — that's the common
     // first-call case. Nothing to do.
+  }
+}
+
+/**
+ * Size check that closes the TOCTOU window: we inspect the file via the fd
+ * we've just opened, rather than `statSync`ing the path a moment before
+ * opening it. Returns `true` if the caller should rotate before writing.
+ */
+function shouldRotateFd(fd: number): boolean {
+  try {
+    return fstatSync(fd).size >= ROTATE_BYTES;
+  } catch {
+    return false;
   }
 }
 
@@ -156,7 +161,6 @@ export function appendAuditEvent(type: AuditEventType, fields: Record<string, un
   try {
     ensureHome();
     const path = getAuditLogPath();
-    maybeRotate(path);
 
     const payload = {
       ts: new Date().toISOString(),
@@ -169,12 +173,18 @@ export function appendAuditEvent(type: AuditEventType, fields: Record<string, un
     // them, so the `\n` terminator is unambiguous.
     const line = `${JSON.stringify(payload)}\n`;
 
-    const fd = openSync(
-      path,
-      // eslint-disable-next-line no-bitwise -- standard POSIX flag combination
-      fsConstants.O_APPEND | fsConstants.O_CREAT | fsConstants.O_WRONLY,
-      0o600,
-    );
+    // Open first, then size-check via fstatSync on the fd — this closes the
+    // TOCTOU window where another writer could grow the file between a
+    // path-level statSync and the open that followed it. If we need to
+    // rotate we close, rename, and reopen a fresh 0600 file.
+    // eslint-disable-next-line no-bitwise -- standard POSIX flag combination
+    const openFlags = fsConstants.O_APPEND | fsConstants.O_CREAT | fsConstants.O_WRONLY;
+    let fd = openSync(path, openFlags, 0o600);
+    if (shouldRotateFd(fd)) {
+      closeSync(fd);
+      rotateNow(path);
+      fd = openSync(path, openFlags, 0o600);
+    }
     try {
       writeSync(fd, line);
     } finally {
@@ -204,7 +214,7 @@ export function appendAuditEvent(type: AuditEventType, fields: Record<string, un
 export function tailAuditLog(n: number): Array<Record<string, unknown>> {
   const path = getAuditLogPath();
   if (!existsSync(path)) return [];
-  const raw = readFileSync(path, 'utf-8');
+  const raw = readTailBytes(path);
   const lines = raw.split('\n').filter((l) => l.length > 0);
   const tail = n >= lines.length ? lines : lines.slice(lines.length - n);
   const out: Array<Record<string, unknown>> = [];
@@ -219,10 +229,59 @@ export function tailAuditLog(n: number): Array<Record<string, unknown>> {
 }
 
 /**
+ * Read either the whole file (if under {@link TAIL_WHOLE_FILE_LIMIT}) or the
+ * last {@link TAIL_WINDOW_BYTES} bytes. For the windowed path we drop the
+ * first line of what we read in case we sliced mid-line — the caller only
+ * cares about the tail, not the head of the window. This keeps memory and
+ * wall-clock flat once the log is in the hundreds-of-KiB range (100k lines
+ * is ~18 MiB at typical shape — reading the whole thing spikes ~50ms).
+ */
+function readTailBytes(path: string): string {
+  let fd: number | null = null;
+  try {
+    fd = openSync(path, fsConstants.O_RDONLY);
+    const size = fstatSync(fd).size;
+    if (size <= TAIL_WHOLE_FILE_LIMIT) {
+      closeSync(fd);
+      fd = null;
+      return readFileSync(path, 'utf-8');
+    }
+    const window = Math.min(TAIL_WINDOW_BYTES, size);
+    const buf = Buffer.alloc(window);
+    readSync(fd, buf, 0, window, size - window);
+    const text = buf.toString('utf-8');
+    // If we didn't start at byte 0, the first line is almost certainly a
+    // partial — drop it.
+    const firstNewline = text.indexOf('\n');
+    return firstNewline === -1 ? '' : text.slice(firstNewline + 1);
+  } catch {
+    return '';
+  } finally {
+    if (fd !== null) closeSync(fd);
+  }
+}
+
+/** Threshold below which `tailAuditLog` just reads the whole file. */
+const TAIL_WHOLE_FILE_LIMIT = 1 * 1024 * 1024;
+/** Window size used when tailing a file larger than {@link TAIL_WHOLE_FILE_LIMIT}. */
+const TAIL_WINDOW_BYTES = 64 * 1024;
+
+/**
  * Manually invoke the rotation check. Exposed for tests; the normal path
- * rotates lazily inside {@link appendAuditEvent}.
+ * rotates lazily inside {@link appendAuditEvent}. Uses the same fd-based
+ * size check as the normal path so the TOCTOU semantics are identical.
  */
 export function rotateIfNeeded(): void {
   const path = getAuditLogPath();
-  maybeRotate(path);
+  if (!existsSync(path)) return;
+  let fd: number | null = null;
+  try {
+    fd = openSync(path, fsConstants.O_RDONLY);
+    if (!shouldRotateFd(fd)) return;
+  } catch {
+    return;
+  } finally {
+    if (fd !== null) closeSync(fd);
+  }
+  rotateNow(path);
 }

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -148,15 +148,10 @@ export async function syncAllConnections(
       const errorMessage = err instanceof Error ? err.message : String(err);
       ctx.logger?.error(`[${conn.providerName}] ${errorMessage}`);
       // Connection-level failure (i.e. a throw that escaped syncConnection,
-      // typically an AuthError on /accounts). `syncConnection` itself emits
-      // the `sync.started` event before it can throw, so we only need the
-      // failure half here. Error class, not message, is recorded — messages
-      // may contain URLs or provider-side detail worth keeping out of the
-      // long-lived audit file.
-      appendAuditEvent('sync.failed', {
-        connection_id: conn.id,
-        error_class: err instanceof Error ? err.constructor.name : 'unknown',
-      });
+      // typically an AuthError on /accounts). The authoritative `sync.failed`
+      // audit event is emitted inside `syncConnection`'s own catch so there's
+      // exactly one emit per failed connection, regardless of whether the
+      // failure mode was "all accounts failed" or "threw before terminal".
       const completedAt = now();
       const durationMs = completedAt.getTime() - startedAt.getTime();
       const status: ConnectionSyncResult['status'] = 'failed';
@@ -219,20 +214,48 @@ export async function syncConnection(
   opts: SyncOptions,
   ctx: Required<Pick<SyncContext, 'db' | 'now'>> & SyncContext,
 ): Promise<ConnectionSyncResult> {
-  const startedAt = ctx.now();
-  const db = ctx.db ?? defaultDb;
-  const now = ctx.now;
-  const logger = ctx.logger;
-
-  // Audit boundary: one `sync.started` per connection attempted. The
-  // orchestrator records the matching success/partial/failure below (or
-  // catches a throw at the caller and emits `sync.failed` there). `dry_run`
-  // is part of the shape so we can later tell real syncs apart from
-  // `--dry-run` rehearsals during audits.
+  // Audit boundary: one `sync.started` per connection attempted, and exactly
+  // one terminal event (`sync.completed` or `sync.failed`) regardless of
+  // whether the failure mode is "all accounts failed but we returned" or
+  // "something threw before we reached the terminal block". `dry_run` is
+  // part of the shape so we can later tell real syncs apart from `--dry-run`
+  // rehearsals during audits.
   appendAuditEvent('sync.started', {
     connection_id: conn.id,
     dry_run: Boolean(opts.dryRun),
   });
+
+  try {
+    return await runSyncConnection(conn, client, opts, ctx);
+  } catch (err) {
+    // Single authoritative failure emit for the throw-escapes path. The
+    // orchestrator catches and records the sync log row — audit wise we
+    // just need the event to land before the error bubbles.
+    appendAuditEvent('sync.failed', {
+      connection_id: conn.id,
+      error_class: err instanceof Error ? err.constructor.name : 'unknown',
+    });
+    throw err;
+  }
+}
+
+/**
+ * Inner body of {@link syncConnection} — kept as a private helper so the
+ * outer function can wrap it in a single try/catch that emits exactly one
+ * `sync.failed` event for any throw path. All existing semantics (per-account
+ * isolation, terminal state audit emit, sync log row writes) remain inside
+ * here unchanged.
+ */
+async function runSyncConnection(
+  conn: Connection,
+  client: TrueLayerClient,
+  opts: SyncOptions,
+  ctx: Required<Pick<SyncContext, 'db' | 'now'>> & SyncContext,
+): Promise<ConnectionSyncResult> {
+  const startedAt = ctx.now();
+  const db = ctx.db ?? defaultDb;
+  const now = ctx.now;
+  const logger = ctx.logger;
 
   const config = safeLoadConfig();
   const defaultHistoryDays = clampHistoryDays(

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -24,6 +24,7 @@ import {
   upsertAccount,
 } from '../db/queries/sync';
 import type * as schema from '../db/schema';
+import { appendAuditEvent } from '../lib/audit';
 import { loadConfig } from '../lib/config';
 import { AuthError, FerretError } from '../lib/errors';
 import type { Account, Connection, NewTransaction } from '../types/domain';
@@ -146,6 +147,16 @@ export async function syncAllConnections(
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);
       ctx.logger?.error(`[${conn.providerName}] ${errorMessage}`);
+      // Connection-level failure (i.e. a throw that escaped syncConnection,
+      // typically an AuthError on /accounts). `syncConnection` itself emits
+      // the `sync.started` event before it can throw, so we only need the
+      // failure half here. Error class, not message, is recorded — messages
+      // may contain URLs or provider-side detail worth keeping out of the
+      // long-lived audit file.
+      appendAuditEvent('sync.failed', {
+        connection_id: conn.id,
+        error_class: err instanceof Error ? err.constructor.name : 'unknown',
+      });
       const completedAt = now();
       const durationMs = completedAt.getTime() - startedAt.getTime();
       const status: ConnectionSyncResult['status'] = 'failed';
@@ -212,6 +223,16 @@ export async function syncConnection(
   const db = ctx.db ?? defaultDb;
   const now = ctx.now;
   const logger = ctx.logger;
+
+  // Audit boundary: one `sync.started` per connection attempted. The
+  // orchestrator records the matching success/partial/failure below (or
+  // catches a throw at the caller and emits `sync.failed` there). `dry_run`
+  // is part of the shape so we can later tell real syncs apart from
+  // `--dry-run` rehearsals during audits.
+  appendAuditEvent('sync.started', {
+    connection_id: conn.id,
+    dry_run: Boolean(opts.dryRun),
+  });
 
   const config = safeLoadConfig();
   const defaultHistoryDays = clampHistoryDays(
@@ -324,6 +345,27 @@ export async function syncConnection(
       },
       db,
     );
+  }
+
+  // Audit: terminal state for this connection. Counts are already
+  // PRD-sanctioned user-local data (no merchant names, no amounts).
+  // `sync.failed` here is the "all accounts failed" shape; a throw that
+  // escapes this function produces `sync.failed` in the orchestrator
+  // catch-block instead.
+  if (status === 'failed') {
+    appendAuditEvent('sync.failed', {
+      connection_id: conn.id,
+      accounts: accountCount,
+    });
+  } else {
+    appendAuditEvent('sync.completed', {
+      connection_id: conn.id,
+      status,
+      accounts: accountCount,
+      transactions_added: totalAdded,
+      transactions_updated: totalUpdated,
+      duration_ms: completedAt.getTime() - startedAt.getTime(),
+    });
   }
 
   return {

--- a/tests/unit/audit.test.ts
+++ b/tests/unit/audit.test.ts
@@ -1,0 +1,188 @@
+// Unit tests for the append-only audit log (issue #48).
+//
+// Each test isolates `$HOME` to a fresh tmpdir so the module's lazy
+// `process.env.HOME` lookup (see `src/lib/audit.ts > getAuditLogPath`) reads
+// a clean state. The module exposes no mutable singletons, so there's
+// nothing to reset between tests beyond the env var.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  REDACTED,
+  ROTATE_BYTES,
+  appendAuditEvent,
+  getAuditLogPath,
+  getAuditLogRotatedPath,
+  redactSecrets,
+  rotateIfNeeded,
+  tailAuditLog,
+} from '../../src/lib/audit';
+
+describe('audit log', () => {
+  let originalHome: string | undefined;
+  let tmp: string;
+
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    tmp = mkdtempSync(join(tmpdir(), 'ferret-audit-'));
+    process.env.HOME = tmp;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) {
+      process.env.HOME = undefined;
+    } else {
+      process.env.HOME = originalHome;
+    }
+  });
+
+  test('appendAuditEvent writes a single JSONL line per event', () => {
+    appendAuditEvent('connection.linked', { connection_id: 'abc', provider_id: 'uk-ob-lloyds' });
+    appendAuditEvent('connection.unlinked', { connection_id: 'abc' });
+
+    const raw = readFileSync(getAuditLogPath(), 'utf-8');
+    const lines = raw.split('\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(2);
+
+    for (const line of lines) {
+      // Every line must be valid JSON and must contain no embedded newline.
+      expect(line.includes('\n')).toBe(false);
+      const parsed = JSON.parse(line);
+      expect(typeof parsed.ts).toBe('string');
+      expect(new Date(parsed.ts).toString()).not.toBe('Invalid Date');
+      expect(typeof parsed.type).toBe('string');
+    }
+
+    const first = JSON.parse(lines[0] ?? '');
+    expect(first.type).toBe('connection.linked');
+    expect(first.connection_id).toBe('abc');
+    expect(first.provider_id).toBe('uk-ob-lloyds');
+  });
+
+  test('log file is created with 0600 mode', () => {
+    appendAuditEvent('config.changed', { key: 'display.show_colors' });
+    const st = statSync(getAuditLogPath());
+    // Mask the permission bits out of the mode; file-type bits live above 0o777.
+    expect(st.mode & 0o777).toBe(0o600);
+  });
+
+  test('0600 mode is preserved across subsequent appends', () => {
+    appendAuditEvent('config.changed', { key: 'a' });
+    const st1 = statSync(getAuditLogPath());
+    expect(st1.mode & 0o777).toBe(0o600);
+
+    appendAuditEvent('config.changed', { key: 'b' });
+    const st2 = statSync(getAuditLogPath());
+    expect(st2.mode & 0o777).toBe(0o600);
+  });
+
+  test('rotation moves log to audit.log.1 when it exceeds 5 MiB', () => {
+    const path = getAuditLogPath();
+    // Pre-seed the file with >ROTATE_BYTES bytes so the next append triggers
+    // the rollover. We stuff the bytes directly — building the same size via
+    // appendAuditEvent would take thousands of iterations and slow the suite.
+    const dir = join(tmp, '.ferret');
+    // Need to seed the parent dir first; appendAuditEvent would do this but
+    // we're side-stepping it to avoid the appended line counting towards
+    // size before the rotation check.
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    const big = 'x'.repeat(ROTATE_BYTES + 1024);
+    writeFileSync(path, big, { mode: 0o600 });
+
+    appendAuditEvent('connection.linked', { connection_id: 'post-rotate' });
+
+    const rotated = getAuditLogRotatedPath();
+    expect(existsSync(rotated)).toBe(true);
+
+    // Rotated file keeps the pre-rotation seed; primary log has one fresh
+    // event only.
+    const primary = readFileSync(path, 'utf-8')
+      .split('\n')
+      .filter((l) => l.length > 0);
+    expect(primary).toHaveLength(1);
+    const evt = JSON.parse(primary[0] ?? '');
+    expect(evt.connection_id).toBe('post-rotate');
+
+    // Rotated file retains 0600.
+    const st = statSync(rotated);
+    expect(st.mode & 0o777).toBe(0o600);
+  });
+
+  test('rotateIfNeeded is a no-op below the threshold', () => {
+    appendAuditEvent('config.changed', { key: 'small' });
+    rotateIfNeeded();
+    expect(existsSync(getAuditLogRotatedPath())).toBe(false);
+  });
+
+  test('redactSecrets strips fields whose keys match the secret pattern', () => {
+    const input = {
+      connection_id: 'keep-me',
+      access_token: 'CANARY-ACCESS-TOKEN-VALUE',
+      refresh_token: 'CANARY-REFRESH-TOKEN-VALUE',
+      api_key: 'CANARY-API-KEY-VALUE',
+      apiKey: 'CANARY-CAMEL-API-KEY',
+      secret: 'CANARY-SECRET',
+      password: 'CANARY-PASSWORD',
+      Authorization: 'Bearer CANARY-AUTH',
+      nested: {
+        refresh: 'CANARY-NESTED-REFRESH',
+        ok_field: 'visible',
+      },
+    };
+    const out = redactSecrets(input);
+    expect(out.connection_id).toBe('keep-me');
+    expect(out.access_token).toBe(REDACTED);
+    expect(out.refresh_token).toBe(REDACTED);
+    expect(out.api_key).toBe(REDACTED);
+    expect(out.apiKey).toBe(REDACTED);
+    expect(out.secret).toBe(REDACTED);
+    expect(out.password).toBe(REDACTED);
+    expect(out.Authorization).toBe(REDACTED);
+    const nested = out.nested as Record<string, unknown>;
+    expect(nested.refresh).toBe(REDACTED);
+    expect(nested.ok_field).toBe('visible');
+  });
+
+  test('appendAuditEvent redacts secret-shaped fields before write', () => {
+    // Canary values must never appear in the on-disk log, even if callers
+    // accidentally pass them in. The redactor is the defence-in-depth.
+    const CANARY = 'CANARY-xyz-987';
+    appendAuditEvent('connection.linked', {
+      connection_id: 'visible-conn',
+      token: CANARY,
+      refresh_token: CANARY,
+      api_key: CANARY,
+      password: CANARY,
+      Authorization: `Bearer ${CANARY}`,
+    });
+
+    const raw = readFileSync(getAuditLogPath(), 'utf-8');
+    expect(raw).not.toContain(CANARY);
+    expect(raw).toContain('visible-conn');
+    expect(raw).toContain(REDACTED);
+  });
+
+  test('tailAuditLog returns the last N parsed events', () => {
+    appendAuditEvent('config.changed', { key: 'one' });
+    appendAuditEvent('config.changed', { key: 'two' });
+    appendAuditEvent('config.changed', { key: 'three' });
+
+    const tail = tailAuditLog(2);
+    expect(tail).toHaveLength(2);
+    expect(tail[0]?.key).toBe('two');
+    expect(tail[1]?.key).toBe('three');
+  });
+
+  test('tailAuditLog returns [] when the log does not exist', () => {
+    expect(tailAuditLog(10)).toEqual([]);
+  });
+
+  test('appendAuditEvent never throws on write errors', () => {
+    // Clobber HOME with a non-writable path. The module must swallow the
+    // failure silently — audit logging is best-effort by design.
+    process.env.HOME = '/dev/null/definitely-not-a-dir';
+    expect(() => appendAuditEvent('config.changed', { key: 'x' })).not.toThrow();
+  });
+});

--- a/tests/unit/audit.test.ts
+++ b/tests/unit/audit.test.ts
@@ -31,8 +31,12 @@ describe('audit log', () => {
   });
 
   afterEach(() => {
+    // `process.env.HOME = undefined` would coerce to the literal string
+    // "undefined" (node's env object stringifies assignments), which is worse
+    // than leaving the real original value alone. Use `Reflect.deleteProperty`
+    // to *un-set* the key when HOME wasn't present before the test.
     if (originalHome === undefined) {
-      process.env.HOME = undefined;
+      Reflect.deleteProperty(process.env, 'HOME');
     } else {
       process.env.HOME = originalHome;
     }
@@ -184,5 +188,49 @@ describe('audit log', () => {
     // failure silently — audit logging is best-effort by design.
     process.env.HOME = '/dev/null/definitely-not-a-dir';
     expect(() => appendAuditEvent('config.changed', { key: 'x' })).not.toThrow();
+  });
+
+  test('sync lifecycle events land with the expected shape', () => {
+    // Direct call-site parity: the sync service emits exactly these three
+    // event types with these field shapes. Keeping the test at the audit-
+    // module boundary (rather than wiring a fake TrueLayer client) avoids
+    // coupling the audit suite to DB fixtures while still guarding the
+    // on-disk JSONL contract that dashboards and `ferret audit` will read.
+    appendAuditEvent('sync.started', {
+      connection_id: 'conn-1',
+      dry_run: false,
+    });
+    appendAuditEvent('sync.completed', {
+      connection_id: 'conn-1',
+      status: 'success',
+      accounts: 2,
+      transactions_added: 14,
+      transactions_updated: 0,
+      duration_ms: 123,
+    });
+    appendAuditEvent('sync.failed', {
+      connection_id: 'conn-2',
+      error_class: 'AuthError',
+    });
+
+    const tail = tailAuditLog(3);
+    expect(tail).toHaveLength(3);
+
+    const [started, completed, failed] = tail;
+    expect(started?.type).toBe('sync.started');
+    expect(started?.connection_id).toBe('conn-1');
+    expect(started?.dry_run).toBe(false);
+
+    expect(completed?.type).toBe('sync.completed');
+    expect(completed?.connection_id).toBe('conn-1');
+    expect(completed?.status).toBe('success');
+    expect(completed?.accounts).toBe(2);
+    expect(completed?.transactions_added).toBe(14);
+    expect(completed?.transactions_updated).toBe(0);
+    expect(typeof completed?.duration_ms).toBe('number');
+
+    expect(failed?.type).toBe('sync.failed');
+    expect(failed?.connection_id).toBe('conn-2');
+    expect(failed?.error_class).toBe('AuthError');
   });
 });


### PR DESCRIPTION
Closes #48. Part of epic #36 (ISO 27001 A.12 / SOC 2 CC7).

## Summary

Introduces `src/lib/audit.ts` — an append-only JSONL audit log at `~/.ferret/audit.log` with atomic writes (`O_APPEND|O_CREAT|O_WRONLY` + single `writeSync`), `0600` permissions preserved across rotation, and single-rollover rotation at 5 MiB. Wired into every security-significant command.

## Events emitted

- `connection.linked` (link) — connection id, provider id, account/card discovery counts
- `connection.unlinked` (unlink) — connection id, provider id, keychain entry count
- `config.changed` (config set) — dot-path key only (value omitted per issue #48)
- `rule.added` / `rule.removed` (rules) — rule id, field, category, priority (pattern excluded)
- `budget.set` / `budget.removed` (budget) — category only (amount omitted per issue #48)
- `sync.started` / `sync.completed` / `sync.failed` (services/sync) — per-connection boundary with counts and duration
- `import.completed` (import) — format, rows_added, rows_duplicate (filename excluded)
- `ask.invoked` (ask) — tool_calls_count, iterations (question and answer excluded)

`connections.reauth_marked` is not emitted from `connections.ts` — that command only lists, never marks. The `needs_reauth` status flip happens inside services/sync and services/truelayer paths that already emit `sync.failed`.

## Redaction invariant

Every audit write runs its fields through `redactSecrets()`, which replaces any key matching `/(token|secret|api_?key|password|refresh|authorization)/i` with `[REDACTED]` recursively. This is the defence-in-depth layer; callers still avoid passing raw secrets. The test suite stuffs canary tokens into an event and asserts the canary never appears in the on-disk log.

## Test plan

- [x] `bun run check` — biome clean
- [x] `bunx tsc --noEmit` — typecheck clean
- [x] `bun test` — 325 pass, 0 fail
- [x] Smoke: `HOME=$(mktemp -d) bun run src/cli.ts init && config set ... && rules add ... && budget set ...` produces 3 JSONL lines and `stat` reports `-rw-------`
- [x] Unit suite covers JSONL shape, 0600 mode on create + subsequent appends, 5 MiB rotation, redaction of access_token / refresh_token / api_key / apiKey / secret / password / Authorization / nested.refresh, canary never appears on disk, tail pagination, never-throws guarantee

🤖 Generated with [Claude Code](https://claude.com/claude-code)