### PR TITLE
feat(setup): interactive credentials + OAuth port bootstrap

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,10 @@
 import { defineCommand, runMain } from 'citty';
 import pkg from '../package.json' with { type: 'json' };
 import { subCommands } from './commands';
+import { loadFerretEnv } from './lib/env-file';
 import { FerretError } from './lib/errors';
+
+loadFerretEnv();
 
 const main = defineCommand({
   meta: {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -21,6 +21,7 @@ import ls from './ls';
 import purge from './purge';
 import remove from './remove';
 import rules from './rules';
+import setup from './setup';
 import sync from './sync';
 import tag from './tag';
 import unlink from './unlink';
@@ -43,6 +44,7 @@ export const subCommands: Record<string, CommandDef<any>> = {
   purge,
   remove,
   rules,
+  setup,
   sync,
   tag,
   unlink,

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,0 +1,215 @@
+// `ferret setup` — interactive bootstrap for credentials + OAuth redirect.
+//
+// Collects the three secrets the rest of the CLI needs (TrueLayer client id
+// & secret, Anthropic API key) and an optional OAuth callback port, then
+// persists them in the two storage paths PRD §9.1 documents:
+//   - secrets → OS keychain (service `ferret`) via `keytar`
+//   - OAuth port → `~/.ferret/.env` so `ferret link` can bind a stable URI
+//
+// The command is idempotent: existing values show up as defaults in the
+// prompt, so re-running `ferret setup` after rotating a credential is safe.
+// After writing, it prints the fully-formed `http://localhost:<port>/callback`
+// URL and a nudge toward TrueLayer's free developer console, which is where
+// the redirect URI actually has to be registered before `ferret link` works.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { defineCommand } from 'citty';
+import consola from 'consola';
+import { ferretHome } from '../lib/config';
+import { envFilePath, parseEnvFile } from '../lib/env-file';
+import { ValidationError } from '../lib/errors';
+import {
+  ANTHROPIC_API_KEY,
+  TRUELAYER_CLIENT_ID,
+  TRUELAYER_CLIENT_SECRET,
+  tryResolveSecret,
+} from '../lib/secrets';
+import { setToken } from '../services/keychain';
+
+const TRUELAYER_CONSOLE_URL = 'https://console.truelayer.com/';
+
+// Port range matches the random fallback used in services/oauth.ts so a
+// suggested default will always be in the same band the live app may already
+// have whitelisted.
+const PORT_MIN = 8000;
+const PORT_MAX = 9999;
+
+function isValidPort(n: number): boolean {
+  return Number.isInteger(n) && n >= 1 && n <= 65535;
+}
+
+// Binds port 0 on loopback to let the kernel pick a free port, then closes.
+// The returned number is free *at this instant* — a later binder could still
+// race us for it, but for a setup-time default that's good enough; the user
+// can always override if they hit a collision at `ferret link` time.
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (addr && typeof addr === 'object' && typeof addr.port === 'number') {
+        const port = addr.port;
+        server.close((err) => (err ? reject(err) : resolve(port)));
+      } else {
+        server.close();
+        reject(new Error('Could not determine a free port from the OS.'));
+      }
+    });
+  });
+}
+
+async function suggestedDefaultPort(): Promise<number> {
+  try {
+    const picked = await findFreePort();
+    if (picked >= PORT_MIN && picked <= PORT_MAX) return picked;
+    // Kernel handed us something outside our band (e.g. ephemeral range on
+    // Linux starts at 32768). Fall back to a stable mid-band value so the
+    // user sees a predictable suggestion.
+  } catch {
+    // ignore — fall through to stable default
+  }
+  return 8765;
+}
+
+async function promptRequired(label: string, currentlySet: boolean): Promise<string> {
+  // Consola's text prompt has no mask option, so secrets echo to the terminal.
+  // This is acceptable for a single-user local CLI; we mitigate by offering to
+  // keep the existing value when one is already stored.
+  while (true) {
+    const hint = currentlySet ? ' (press enter to keep the existing value)' : '';
+    const value = (await consola.prompt(`${label}${hint}`, {
+      type: 'text',
+      cancel: 'reject',
+    })) as string;
+    const trimmed = (value ?? '').trim();
+    if (trimmed.length > 0) return trimmed;
+    if (currentlySet) return '';
+    consola.warn(`${label} is required.`);
+  }
+}
+
+function upsertEnvLine(existing: string, key: string, value: string): string {
+  const lines = existing.split(/\r?\n/);
+  let replaced = false;
+  const out: string[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      out.push(line);
+      continue;
+    }
+    const eq = trimmed.indexOf('=');
+    if (eq > 0 && trimmed.slice(0, eq).trim() === key) {
+      if (!replaced) {
+        out.push(`${key}=${value}`);
+        replaced = true;
+      }
+      // Drop duplicate subsequent assignments.
+      continue;
+    }
+    out.push(line);
+  }
+  if (!replaced) {
+    if (out.length > 0 && out[out.length - 1]?.trim() !== '') out.push('');
+    out.push(`${key}=${value}`);
+  }
+  // Ensure trailing newline for POSIX tools.
+  return `${out.join('\n').replace(/\n+$/, '')}\n`;
+}
+
+function writeOauthPort(port: number): string {
+  const path = envFilePath();
+  const dir = ferretHome();
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+
+  const existing = existsSync(path) ? readFileSync(path, 'utf-8') : '';
+  const next = upsertEnvLine(existing, 'FERRET_OAUTH_PORT', String(port));
+  writeFileSync(path, next, { mode: 0o600 });
+  return path;
+}
+
+export default defineCommand({
+  meta: {
+    name: 'setup',
+    description: 'Interactively capture TrueLayer + Anthropic credentials and OAuth port',
+  },
+  async run() {
+    consola.info(
+      "ferret setup — you'll need a free TrueLayer developer account (https://console.truelayer.com/) and an Anthropic API key.",
+    );
+
+    const existingClientId = await tryResolveSecret(TRUELAYER_CLIENT_ID);
+    const existingClientSecret = await tryResolveSecret(TRUELAYER_CLIENT_SECRET);
+    const existingAnthropicKey = await tryResolveSecret(ANTHROPIC_API_KEY);
+
+    const clientId = await promptRequired('TRUELAYER_CLIENT_ID', existingClientId !== null);
+    const clientSecret = await promptRequired(
+      'TRUELAYER_CLIENT_SECRET',
+      existingClientSecret !== null,
+    );
+    const anthropicKey = await promptRequired('ANTHROPIC_API_KEY', existingAnthropicKey !== null);
+
+    // Determine a sensible port default: prefer what the user already has
+    // configured (shell env, previously-written file), otherwise ask the OS
+    // for a free one. Offering a specific number as the default makes the
+    // prompt feel concrete instead of open-ended.
+    const envFile = envFilePath();
+    const existingPortEnv = process.env.FERRET_OAUTH_PORT;
+    let portDefault: number;
+    if (existingPortEnv && isValidPort(Number.parseInt(existingPortEnv, 10))) {
+      portDefault = Number.parseInt(existingPortEnv, 10);
+    } else if (existsSync(envFile)) {
+      const parsed = parseEnvFile(readFileSync(envFile, 'utf-8'));
+      const fromFile = Number.parseInt(parsed.FERRET_OAUTH_PORT ?? '', 10);
+      portDefault = isValidPort(fromFile) ? fromFile : await suggestedDefaultPort();
+    } else {
+      portDefault = await suggestedDefaultPort();
+    }
+
+    const portRaw = (await consola.prompt(
+      `OAuth callback port (press enter for default ${portDefault})`,
+      {
+        type: 'text',
+        default: String(portDefault),
+        cancel: 'reject',
+      },
+    )) as string;
+    const portTrimmed = (portRaw ?? '').trim();
+    const portNumber = portTrimmed.length === 0 ? portDefault : Number.parseInt(portTrimmed, 10);
+    if (!isValidPort(portNumber)) {
+      throw new ValidationError(
+        `OAuth port must be an integer in 1–65535 (got "${portTrimmed || portRaw}").`,
+      );
+    }
+
+    if (clientId !== '') {
+      await setToken(TRUELAYER_CLIENT_ID.keychainAccount, clientId);
+    }
+    if (clientSecret !== '') {
+      await setToken(TRUELAYER_CLIENT_SECRET.keychainAccount, clientSecret);
+    }
+    if (anthropicKey !== '') {
+      await setToken(ANTHROPIC_API_KEY.keychainAccount, anthropicKey);
+    }
+    const writtenEnvPath = writeOauthPort(portNumber);
+
+    const callbackUrl = `http://localhost:${portNumber}/callback`;
+    consola.success('Credentials stored in the OS keychain.');
+    consola.info(`OAuth port ${portNumber} saved to ${writtenEnvPath}.`);
+    consola.box(
+      [
+        'Next step — register the redirect URI in TrueLayer:',
+        '',
+        `  1. Open ${TRUELAYER_CONSOLE_URL} (free developer account).`,
+        '  2. In your app settings, add this as an Allowed Redirect URI:',
+        '',
+        `       ${callbackUrl}`,
+        '',
+        '  3. Save, then run `ferret link` to connect your bank.',
+      ].join('\n'),
+    );
+  },
+});

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -12,12 +12,12 @@
 // URL and a nudge toward TrueLayer's free developer console, which is where
 // the redirect URI actually has to be registered before `ferret link` works.
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:net';
 import { defineCommand } from 'citty';
 import consola from 'consola';
 import { ferretHome } from '../lib/config';
-import { envFilePath, parseEnvFile } from '../lib/env-file';
+import { envFilePath, parseEnvFile, readFileOrEmpty, upsertEnvLine } from '../lib/env-file';
 import { ValidationError } from '../lib/errors';
 import {
   ANTHROPIC_API_KEY,
@@ -26,14 +26,12 @@ import {
   tryResolveSecret,
 } from '../lib/secrets';
 import { setToken } from '../services/keychain';
+// Re-use the live OAuth band so `ferret setup` suggests a port that
+// `ferret link` can actually bind. Importing from a single source keeps
+// the two sides from drifting if the range is ever widened.
+import { PORT_MAX, PORT_MIN } from '../services/oauth';
 
 const TRUELAYER_CONSOLE_URL = 'https://console.truelayer.com/';
-
-// Port range matches the random fallback used in services/oauth.ts so a
-// suggested default will always be in the same band the live app may already
-// have whitelisted.
-const PORT_MIN = 8000;
-const PORT_MAX = 9999;
 
 function isValidPort(n: number): boolean {
   return Number.isInteger(n) && n >= 1 && n <= 65535;
@@ -91,43 +89,21 @@ async function promptRequired(label: string, currentlySet: boolean): Promise<str
   }
 }
 
-function upsertEnvLine(existing: string, key: string, value: string): string {
-  const lines = existing.split(/\r?\n/);
-  let replaced = false;
-  const out: string[] = [];
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) {
-      out.push(line);
-      continue;
-    }
-    const eq = trimmed.indexOf('=');
-    if (eq > 0 && trimmed.slice(0, eq).trim() === key) {
-      if (!replaced) {
-        out.push(`${key}=${value}`);
-        replaced = true;
-      }
-      // Drop duplicate subsequent assignments.
-      continue;
-    }
-    out.push(line);
-  }
-  if (!replaced) {
-    if (out.length > 0 && out[out.length - 1]?.trim() !== '') out.push('');
-    out.push(`${key}=${value}`);
-  }
-  // Ensure trailing newline for POSIX tools.
-  return `${out.join('\n').replace(/\n+$/, '')}\n`;
-}
-
 function writeOauthPort(port: number): string {
   const path = envFilePath();
   const dir = ferretHome();
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
 
-  const existing = existsSync(path) ? readFileSync(path, 'utf-8') : '';
+  const existing = readFileOrEmpty(path);
   const next = upsertEnvLine(existing, 'FERRET_OAUTH_PORT', String(port));
-  writeFileSync(path, next, { mode: 0o600 });
+  // Atomic write: write to a sibling temp file first, then rename. Mirrors
+  // `writeConfig` in src/lib/config.ts — an interrupted write (kill -9,
+  // power loss) leaves the original `.env` intact rather than truncated,
+  // which matters because that file can carry TrueLayer / Anthropic
+  // credentials alongside the port value.
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, next, { mode: 0o600 });
+  renameSync(tmp, path);
   return path;
 }
 
@@ -161,12 +137,14 @@ export default defineCommand({
     let portDefault: number;
     if (existingPortEnv && isValidPort(Number.parseInt(existingPortEnv, 10))) {
       portDefault = Number.parseInt(existingPortEnv, 10);
-    } else if (existsSync(envFile)) {
-      const parsed = parseEnvFile(readFileSync(envFile, 'utf-8'));
+    } else {
+      // readFileOrEmpty collapses the previous existsSync + readFileSync
+      // pair into a single syscall, eliminating the TOCTOU race CodeQL
+      // flagged as `js/file-system-race`.
+      const content = readFileOrEmpty(envFile);
+      const parsed = content.length > 0 ? parseEnvFile(content) : {};
       const fromFile = Number.parseInt(parsed.FERRET_OAUTH_PORT ?? '', 10);
       portDefault = isValidPort(fromFile) ? fromFile : await suggestedDefaultPort();
-    } else {
-      portDefault = await suggestedDefaultPort();
     }
 
     const portRaw = (await consola.prompt(

--- a/src/lib/env-file.ts
+++ b/src/lib/env-file.ts
@@ -1,0 +1,55 @@
+// Loads `~/.ferret/.env` into `process.env` at CLI startup.
+//
+// PRD §9.1 / THREAT_MODEL.md document `~/.ferret/.env` as an accepted location
+// for TRUELAYER_CLIENT_*, ANTHROPIC_API_KEY and FERRET_OAUTH_PORT, but Bun's
+// implicit `.env` loader only reads from cwd — not the per-user ferret dir.
+// This helper bridges that gap so values written by `ferret setup` are visible
+// to subsequent runs no matter where the user invokes ferret from.
+//
+// Values already present in `process.env` (shell export, CI secret, etc.) win
+// over the file — the file is a fallback, not an override, so users can
+// temporarily point at a different credential without editing the file.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export function envFilePath(): string {
+  return join(process.env.HOME ?? homedir(), '.ferret', '.env');
+}
+
+export function parseEnvFile(content: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const raw of content.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+export function loadFerretEnv(path: string = envFilePath()): void {
+  if (!existsSync(path)) return;
+  let content: string;
+  try {
+    content = readFileSync(path, 'utf-8');
+  } catch {
+    return;
+  }
+  const parsed = parseEnvFile(content);
+  for (const [k, v] of Object.entries(parsed)) {
+    if (v.length === 0) continue;
+    if (process.env[k] === undefined) process.env[k] = v;
+  }
+}

--- a/src/lib/env-file.ts
+++ b/src/lib/env-file.ts
@@ -10,12 +10,41 @@
 // over the file — the file is a fallback, not an override, so users can
 // temporarily point at a different credential without editing the file.
 
-import { existsSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 export function envFilePath(): string {
   return join(process.env.HOME ?? homedir(), '.ferret', '.env');
+}
+
+/**
+ * Strip a matching leading/trailing quote pair from a value. Requires
+ * at least two characters so a bare `"` or `'` isn't treated as both
+ * the opening and closing quote (which would collapse to an empty
+ * string and hide a genuinely malformed line). For double-quoted
+ * values we expand the standard `\n` / `\t` / `\r` / `\\` / `\"`
+ * escape sequences — this matches the behaviour of dotenv-style
+ * parsers and lets users persist multi-line secrets as a single
+ * line. Single-quoted values are literal per the same convention.
+ */
+function unquote(value: string): string {
+  if (value.length < 2) return value;
+  const first = value[0];
+  const last = value[value.length - 1];
+  if (first === '"' && last === '"') {
+    const inner = value.slice(1, -1);
+    return inner.replace(/\\([ntr\\"])/g, (_, ch: string) => {
+      if (ch === 'n') return '\n';
+      if (ch === 't') return '\t';
+      if (ch === 'r') return '\r';
+      return ch;
+    });
+  }
+  if (first === "'" && last === "'") {
+    return value.slice(1, -1);
+  }
+  return value;
 }
 
 export function parseEnvFile(content: string): Record<string, string> {
@@ -26,21 +55,79 @@ export function parseEnvFile(content: string): Record<string, string> {
     const eq = line.indexOf('=');
     if (eq <= 0) continue;
     const key = line.slice(0, eq).trim();
-    let value = line.slice(eq + 1).trim();
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
     if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
-    out[key] = value;
+    out[key] = unquote(line.slice(eq + 1).trim());
   }
   return out;
 }
 
+/**
+ * Read a file's contents, returning the empty string if the file does
+ * not exist. Using a single readFileSync + ENOENT catch instead of an
+ * existsSync/readFileSync pair closes the TOCTOU window CodeQL flags
+ * as `js/file-system-race`: between the check and the open, an
+ * attacker with write access to the containing directory could
+ * replace the file with a symlink pointing at something sensitive.
+ */
+export function readFileOrEmpty(path: string): string {
+  try {
+    return readFileSync(path, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return '';
+    throw err;
+  }
+}
+
+/**
+ * Upsert a `KEY=value` line into an existing `.env`-style file body,
+ * preserving comments, blank lines, and the relative ordering of
+ * unrelated entries. Duplicate assignments of the same key are
+ * collapsed to a single (replaced) line — the first occurrence wins
+ * its original position, and subsequent ones are dropped. Appending a
+ * brand-new key inserts a separating blank line if the previous
+ * content did not already end with one, and the result is guaranteed
+ * to end in a single newline so POSIX tools read the final line
+ * correctly.
+ */
+export function upsertEnvLine(existing: string, key: string, value: string): string {
+  const lines = existing.split(/\r?\n/);
+  let replaced = false;
+  const out: string[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      out.push(line);
+      continue;
+    }
+    const eq = trimmed.indexOf('=');
+    if (eq > 0 && trimmed.slice(0, eq).trim() === key) {
+      if (!replaced) {
+        out.push(`${key}=${value}`);
+        replaced = true;
+      }
+      // Drop duplicate subsequent assignments.
+      continue;
+    }
+    out.push(line);
+  }
+  if (!replaced) {
+    // Drop trailing blank lines before deciding how much whitespace to
+    // insert — without this, a file that already ends in `\n\n` would
+    // accumulate an extra blank line each time a new key is appended.
+    while (out.length > 0 && out[out.length - 1]?.trim() === '') out.pop();
+    if (out.length > 0) out.push('');
+    out.push(`${key}=${value}`);
+  }
+  // Ensure trailing newline for POSIX tools.
+  return `${out.join('\n').replace(/\n+$/, '')}\n`;
+}
+
 export function loadFerretEnv(path: string = envFilePath()): void {
-  if (!existsSync(path)) return;
+  // Single syscall + ENOENT catch instead of existsSync + readFileSync —
+  // closes the TOCTOU race (js/file-system-race, CWE-367) and also
+  // handles any other transient read error (EACCES, EISDIR, etc.) by
+  // silently treating the file as absent. This is a best-effort env
+  // bootstrap and must not fail CLI startup.
   let content: string;
   try {
     content = readFileSync(path, 'utf-8');

--- a/tests/helpers/expected-commands.ts
+++ b/tests/helpers/expected-commands.ts
@@ -4,6 +4,7 @@
 
 export const EXPECTED_COMMANDS = [
   'init',
+  'setup',
   'link',
   'unlink',
   'remove',

--- a/tests/unit/env-file.test.ts
+++ b/tests/unit/env-file.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  loadFerretEnv,
+  parseEnvFile,
+  readFileOrEmpty,
+  upsertEnvLine,
+} from '../../src/lib/env-file';
+
+describe('parseEnvFile', () => {
+  test('parses plain KEY=value lines', () => {
+    expect(parseEnvFile('FOO=bar\nBAZ=qux')).toEqual({ FOO: 'bar', BAZ: 'qux' });
+  });
+
+  test('trims whitespace around keys and values', () => {
+    expect(parseEnvFile('  FOO  =  bar  ')).toEqual({ FOO: 'bar' });
+  });
+
+  test('skips blank lines and comment lines', () => {
+    const input = ['# comment', '', 'FOO=bar', '   ', '# another', 'BAZ=qux'].join('\n');
+    expect(parseEnvFile(input)).toEqual({ FOO: 'bar', BAZ: 'qux' });
+  });
+
+  test('handles \\r\\n line endings', () => {
+    expect(parseEnvFile('A=1\r\nB=2\r\n')).toEqual({ A: '1', B: '2' });
+  });
+
+  test('rejects keys with invalid characters', () => {
+    // Hyphens, spaces, and leading digits are invalid env-var names
+    // under the POSIX shell grammar we mirror here.
+    const input = ['FOO-BAR=x', '9KEY=y', 'has space=z', 'OK=good'].join('\n');
+    expect(parseEnvFile(input)).toEqual({ OK: 'good' });
+  });
+
+  test('ignores lines without = or starting with =', () => {
+    expect(parseEnvFile('no_equals\n=no_key\nGOOD=yes')).toEqual({ GOOD: 'yes' });
+  });
+
+  test('strips matching double quotes', () => {
+    expect(parseEnvFile('X="hello"')).toEqual({ X: 'hello' });
+  });
+
+  test('strips matching single quotes', () => {
+    expect(parseEnvFile("X='hello'")).toEqual({ X: 'hello' });
+  });
+
+  test('leaves mismatched quotes intact', () => {
+    // Value starts with " but ends with ' — not a matching pair,
+    // so the quotes are preserved as literal characters rather than
+    // silently collapsing to `hello'`.
+    expect(parseEnvFile('X="hello\'')).toEqual({ X: '"hello\'' });
+  });
+
+  test('leaves a single lone quote character intact', () => {
+    // A single " would otherwise be treated as both opening and
+    // closing quote and collapse to the empty string. Guard against
+    // that by requiring length >= 2 before stripping.
+    expect(parseEnvFile('X="')).toEqual({ X: '"' });
+    expect(parseEnvFile("X='")).toEqual({ X: "'" });
+  });
+
+  test('expands escape sequences inside double quotes', () => {
+    expect(parseEnvFile('X="line1\\nline2"')).toEqual({ X: 'line1\nline2' });
+    expect(parseEnvFile('X="col1\\tcol2"')).toEqual({ X: 'col1\tcol2' });
+    expect(parseEnvFile('X="back\\\\slash"')).toEqual({ X: 'back\\slash' });
+    expect(parseEnvFile('X="quote\\""')).toEqual({ X: 'quote"' });
+  });
+
+  test('single quotes are literal — no escape expansion', () => {
+    expect(parseEnvFile("X='line1\\nline2'")).toEqual({ X: 'line1\\nline2' });
+  });
+
+  test('preserves embedded equals signs in values', () => {
+    // The split is on the *first* `=` only — values containing `=`
+    // (e.g. base64-encoded tokens) must round-trip unchanged.
+    expect(parseEnvFile('KEY=a=b=c')).toEqual({ KEY: 'a=b=c' });
+  });
+
+  test('last occurrence of a key wins', () => {
+    // Matches the behaviour most dotenv parsers document.
+    expect(parseEnvFile('X=first\nX=second')).toEqual({ X: 'second' });
+  });
+});
+
+describe('loadFerretEnv', () => {
+  let dir: string;
+  let envPath: string;
+  const savedEnv: Record<string, string | undefined> = {};
+  const keysUnderTest = ['FERRET_TEST_A', 'FERRET_TEST_B', 'FERRET_TEST_C'];
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'ferret-env-file-'));
+    envPath = join(dir, '.env');
+    for (const k of keysUnderTest) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of keysUnderTest) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('returns silently when the file does not exist', () => {
+    loadFerretEnv(join(dir, 'missing.env'));
+    expect(process.env.FERRET_TEST_A).toBeUndefined();
+  });
+
+  test('loads values into process.env when unset', () => {
+    writeFileSync(envPath, 'FERRET_TEST_A=from_file\nFERRET_TEST_B=other\n');
+    loadFerretEnv(envPath);
+    expect(process.env.FERRET_TEST_A).toBe('from_file');
+    expect(process.env.FERRET_TEST_B).toBe('other');
+  });
+
+  test('does NOT override values already set in process.env (shell wins)', () => {
+    process.env.FERRET_TEST_A = 'from_shell';
+    writeFileSync(envPath, 'FERRET_TEST_A=from_file\nFERRET_TEST_B=only_in_file\n');
+    loadFerretEnv(envPath);
+    expect(process.env.FERRET_TEST_A).toBe('from_shell');
+    expect(process.env.FERRET_TEST_B).toBe('only_in_file');
+  });
+
+  test('skips empty values even when process.env slot is unset', () => {
+    writeFileSync(envPath, 'FERRET_TEST_A=\nFERRET_TEST_B=value\n');
+    loadFerretEnv(envPath);
+    expect(process.env.FERRET_TEST_A).toBeUndefined();
+    expect(process.env.FERRET_TEST_B).toBe('value');
+  });
+});
+
+describe('readFileOrEmpty', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'ferret-readfile-'));
+  });
+
+  afterEach(() => {
+    // Restore readable perms on anything we chmod'd so rmSync can tear
+    // the tree down even when a test intentionally revoked access.
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // Best effort — rmSync will still surface a real problem below.
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('returns the file contents when it exists', () => {
+    const path = join(dir, 'a.txt');
+    writeFileSync(path, 'hello');
+    expect(readFileOrEmpty(path)).toBe('hello');
+  });
+
+  test('returns empty string when the file does not exist (ENOENT)', () => {
+    expect(readFileOrEmpty(join(dir, 'missing.txt'))).toBe('');
+  });
+
+  test('rethrows errors that are not ENOENT', () => {
+    // Pass a directory path to force EISDIR — a non-ENOENT error that
+    // the helper should propagate rather than silently swallow.
+    expect(() => readFileOrEmpty(dir)).toThrow();
+  });
+});
+
+describe('upsertEnvLine', () => {
+  test('appends a new KEY=value when the key is not present', () => {
+    expect(upsertEnvLine('', 'FOO', 'bar')).toBe('FOO=bar\n');
+  });
+
+  test('inserts a blank line before appending when the file is non-empty', () => {
+    const result = upsertEnvLine('EXISTING=1\n', 'FOO', 'bar');
+    expect(result).toBe('EXISTING=1\n\nFOO=bar\n');
+  });
+
+  test('does not insert a second blank line if one already trails the file', () => {
+    const result = upsertEnvLine('EXISTING=1\n\n', 'FOO', 'bar');
+    expect(result).toBe('EXISTING=1\n\nFOO=bar\n');
+  });
+
+  test('replaces an existing key in place', () => {
+    const result = upsertEnvLine('FOO=old\nBAR=keep\n', 'FOO', 'new');
+    expect(result).toBe('FOO=new\nBAR=keep\n');
+  });
+
+  test('collapses duplicate assignments of the same key', () => {
+    const result = upsertEnvLine('FOO=a\nBAR=keep\nFOO=b\n', 'FOO', 'new');
+    expect(result).toBe('FOO=new\nBAR=keep\n');
+  });
+
+  test('preserves comments and blank lines', () => {
+    const input = '# header comment\n\nFOO=old\n# trailing comment\n';
+    const result = upsertEnvLine(input, 'FOO', 'new');
+    expect(result).toBe('# header comment\n\nFOO=new\n# trailing comment\n');
+  });
+
+  test('handles \\r\\n input and normalises to \\n output', () => {
+    const result = upsertEnvLine('A=1\r\nB=2\r\n', 'B', '3');
+    expect(result).toBe('A=1\nB=3\n');
+  });
+
+  test('guarantees exactly one trailing newline', () => {
+    expect(upsertEnvLine('A=1', 'B', '2').endsWith('\n')).toBe(true);
+    expect(upsertEnvLine('A=1\n\n\n', 'B', '2').endsWith('\n\n')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- New `ferret setup` command: interactively captures `TRUELAYER_CLIENT_ID`, `TRUELAYER_CLIENT_SECRET`, `ANTHROPIC_API_KEY` into the OS keychain and an optional OAuth callback port into `~/.ferret/.env`. Prints the resulting `http://localhost:<port>/callback` URL and points users at the free TrueLayer developer console to register the redirect URI.
- Auto-loads `~/.ferret/.env` at CLI startup via a small parser, so `FERRET_OAUTH_PORT` written by `setup` reaches `ferret link` regardless of the user's cwd. Shell env still wins over the file.
- Port default comes from the kernel (`net.createServer().listen(0)` on loopback) when nothing is already configured, clamped back to a stable 8765 if the OS hands us something outside the 8000–9999 band.

## Test plan
- [x] `bun run check` (biome)
- [x] `bun run typecheck`
- [x] `bun test` — 340 pass
- [x] `bun run src/cli.ts --help` surfaces `setup`
- [ ] Manual: run `ferret setup`, verify keychain entries, env file, and printed callback URL
- [ ] Manual: with `FERRET_OAUTH_PORT` written by setup, `ferret link` binds that exact port

🤖 Generated with [Claude Code](https://claude.com/claude-code)