### PR TITLE
feat(ask): render markdown answers as ANSI-colored terminal output

### DIFF
--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -212,10 +212,13 @@ function handleEvent(event: AskEvent, ctx: HandleEventCtx): void {
       ctx.onPendingCall({ name: event.name, input: event.input });
       if (ctx.verbose) {
         consola.info(`tool call: ${event.name} ${safeStringify(event.input)}`);
-      } else if (!ctx.wantJson) {
-        // Non-verbose default: surface a subtle hint on stderr so the
-        // user has feedback during long tool loops without polluting
-        // the stdout answer stream.
+      } else if (!ctx.wantJson && process.stderr.isTTY) {
+        // Non-verbose default on an interactive terminal: surface a
+        // subtle hint on stderr so the user has feedback during long
+        // tool loops without polluting the stdout answer stream.
+        // Skip when stderr is piped or redirected — consumers of the
+        // error stream (log collectors, CI captures) don't benefit
+        // from a progress ticker and would only see noise.
         process.stderr.write(picocolors.dim(`  … ${event.name}\n`));
       }
       break;

--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -1,10 +1,13 @@
 // `ferret ask <question>` — natural-language financial query (PRD §4.5).
 //
-// Streams Claude tokens to stdout in default mode; collects them when
-// `--json` is used so the structured payload contains the full answer.
-// `--verbose` echoes tool calls + per-tool summaries to stderr so the
-// user can audit which queries Claude ran without polluting the answer
-// stream.
+// Buffers Claude tokens in default mode and renders markdown → ANSI
+// once the loop finishes, so users see a cleanly formatted answer
+// rather than raw `**bold**` syntax. Tool-call activity surfaces as
+// subtle dim status lines on stderr so the user has feedback while
+// Claude is running tools between turns. `--json` still collects
+// verbatim text (no rendering) so the structured payload stays
+// machine-consumable. `--verbose` keeps its detailed tool-call echo
+// on stderr.
 //
 // SIGINT handling: on Ctrl-C we flip an AbortController so the tool loop
 // exits between iterations rather than ripping out mid-call. Exit code
@@ -18,6 +21,7 @@ import { appendAuditEvent } from '../lib/audit';
 import { loadConfig } from '../lib/config';
 import { FerretError, ValidationError } from '../lib/errors';
 import { formatJson } from '../lib/format';
+import { renderMarkdown } from '../lib/markdown-terminal';
 import { ANTHROPIC_API_KEY, resolveSecret } from '../lib/secrets';
 import { type AskEvent, type BudgetProposal, runAsk } from '../services/ask';
 import { ClaudeClient } from '../services/claude';
@@ -166,9 +170,12 @@ export default defineCommand({
         };
         process.stdout.write(`${formatJson(out)}\n`);
       } else {
-        // Default-mode streamed tokens already wrote as they arrived.
-        // Add a trailing newline so the next shell prompt is on its own line.
-        if (!collected.answer.endsWith('\n')) process.stdout.write('\n');
+        // Render the buffered markdown answer as ANSI-styled text.
+        // Pass a single trailing newline through so the next shell
+        // prompt lands on its own line.
+        const rendered = renderMarkdown(collected.answer);
+        process.stdout.write(rendered);
+        if (!rendered.endsWith('\n')) process.stdout.write('\n');
         if (dedupedProposals.length > 0) {
           renderProposals(dedupedProposals, applyResults);
         }
@@ -195,16 +202,21 @@ interface HandleEventCtx {
 function handleEvent(event: AskEvent, ctx: HandleEventCtx): void {
   switch (event.type) {
     case 'token': {
+      // Buffer only — the final answer is rendered as markdown once
+      // the loop completes so users don't see raw `**bold**` syntax
+      // flickering past.
       ctx.collected.answer += event.text;
-      if (!ctx.wantJson) {
-        process.stdout.write(event.text);
-      }
       break;
     }
     case 'tool_call': {
       ctx.onPendingCall({ name: event.name, input: event.input });
       if (ctx.verbose) {
         consola.info(`tool call: ${event.name} ${safeStringify(event.input)}`);
+      } else if (!ctx.wantJson) {
+        // Non-verbose default: surface a subtle hint on stderr so the
+        // user has feedback during long tool loops without polluting
+        // the stdout answer stream.
+        process.stderr.write(picocolors.dim(`  … ${event.name}\n`));
       }
       break;
     }

--- a/src/lib/markdown-terminal.ts
+++ b/src/lib/markdown-terminal.ts
@@ -26,11 +26,13 @@
 
 import pc from 'picocolors';
 
-// Sentinel character used to bracket placeholder tokens. The section
-// sign is extremely rare in ordinary user-facing text and printable
-// ASCII, so it avoids both the "control character in regex" lint rule
-// and any realistic risk of colliding with legitimate content.
-const SENTINEL = '\u00A7';
+// Sentinel character used to bracket placeholder tokens. U+E000 sits
+// in the Unicode Private Use Area — it has no assigned meaning and
+// will never appear in ordinary user-facing text (merchant names,
+// currency-formatted amounts, etc.), so it avoids both the
+// "control character in regex" lint rule and any realistic risk of
+// colliding with legitimate content.
+const SENTINEL = '\uE000';
 
 /**
  * Transform markdown-flavored text into ANSI-colored output. Input is
@@ -72,16 +74,21 @@ export function renderMarkdown(input: string): string {
     out = out.replace(re, stash);
   }
 
-  // ATX headings on their own line. We only support H1-H3 because Claude
-  // rarely goes deeper and treating deeper levels the same as H3 adds
-  // noise. Render as bold — ANSI has no dedicated "heading" style.
-  out = out.replace(/^\s*#{1,3}\s+(.+?)\s*$/gm, (_, inner: string) => pc.bold(inner));
+  // ATX headings on their own line. Support H1-H6 so deeper levels
+  // (e.g. `#### subhead`) don't leak raw `#` prefixes when Claude
+  // uses them. ANSI has no dedicated heading styles, so every level
+  // renders as bold. The trailing whitespace class is restricted to
+  // spaces/tabs — `\s` would also match the newline that separates
+  // this line from the next, which would swallow the blank line
+  // after a heading and collapse paragraph breaks.
+  out = out.replace(/^[ \t]*#{1,6}[ \t]+(.+?)[ \t]*$/gm, (_, inner: string) => pc.bold(inner));
 
-  // Bold: **text** and __text__. Lazy match so adjacent bolds on one
-  // line (`**a** and **b**`) render as two separate bolds rather than
-  // one span covering everything between the first and last pair.
-  out = out.replace(/\*\*(.+?)\*\*/gs, (_, inner: string) => pc.bold(inner));
-  out = out.replace(/__(.+?)__/g, (_, inner: string) => pc.bold(inner));
+  // Bold: **text** and __text__. Inner content excludes newlines and
+  // asterisks — multi-line bold isn't something Claude emits, and the
+  // explicit character class makes the match linear (no backtracking),
+  // avoiding the ReDoS shape that `.+?` with the `s` flag would have.
+  out = out.replace(/\*\*([^*\n]+)\*\*/g, (_, inner: string) => pc.bold(inner));
+  out = out.replace(/__([^_\n]+)__/g, (_, inner: string) => pc.bold(inner));
 
   // Inline code: single backticks. Cyan so it doesn't fight the bold
   // style already used for emphasis.

--- a/src/lib/markdown-terminal.ts
+++ b/src/lib/markdown-terminal.ts
@@ -1,0 +1,120 @@
+// Minimal markdown → ANSI renderer for `ferret ask`. Claude emits
+// GitHub-flavored markdown (**bold**, `-` bullets, headings, inline
+// code) which shows up as raw syntax if we pipe it straight to stdout.
+// This module converts the handful of constructs Claude actually uses
+// into ANSI escape codes via picocolors, so terminal output looks like
+// the demo on the marketing site instead of unparsed markdown.
+//
+// Styling palette (mirrors the marketing-site mock):
+//   • currency amounts (£/$/€...)    → yellow
+//   • overspend warnings ("£47 over",
+//     "overspent by £X", "(~18% over)",
+//     bare "Overspent" / "Exceeded")  → red (takes precedence over yellow)
+//   • parentheticals w/o currency
+//     (e.g. "(2 visits)")             → dim
+//   • **bold**, __bold__, headings   → bold
+//   • `inline code`                  → cyan
+//   • `-`/`*` bullets                → `•`
+//
+// Not a full markdown parser: links, images, tables, code fences, and
+// block quotes are passed through unchanged because Claude rarely
+// emits them in ask-mode answers. Warning spans are stashed behind
+// placeholders before the other passes run so yellow currency styling
+// doesn't leak inside the red warning segments (ANSI close codes don't
+// restore a surrounding color, so naive nesting produces half-red
+// spans).
+
+import pc from 'picocolors';
+
+// Sentinel character used to bracket placeholder tokens. The section
+// sign is extremely rare in ordinary user-facing text and printable
+// ASCII, so it avoids both the "control character in regex" lint rule
+// and any realistic risk of colliding with legitimate content.
+const SENTINEL = '\u00A7';
+
+/**
+ * Transform markdown-flavored text into ANSI-colored output. Input is
+ * expected to be the full assistant answer; rendering is done as a
+ * batch of text-level regex passes rather than a streaming tokenizer,
+ * because `ferret ask` buffers the whole answer before display.
+ *
+ * Order matters: earlier passes wrap matches in ANSI codes that later
+ * passes must not accidentally re-match. Warning spans are extracted
+ * first (before any coloring) so they can be re-injected atomically
+ * at the end without their contents being re-styled.
+ */
+export function renderMarkdown(input: string): string {
+  let out = input;
+  const warnings: string[] = [];
+  const stash = (match: string): string => {
+    warnings.push(match);
+    return `${SENTINEL}W${warnings.length - 1}${SENTINEL}`;
+  };
+
+  // Warning phrases — stash behind placeholders so later currency /
+  // bold passes don't style the pieces inside. Patterns are ordered
+  // longest-match-first so e.g. "overspent by £61.85" wins over the
+  // bare "£61.85" currency pattern that would otherwise swallow the
+  // amount first.
+  const WARN_PATTERNS: RegExp[] = [
+    // "overspent by £61.85", "exceeded by £61.85"
+    /\b(?:overspent|exceeded)\s+by\s+[£$€]\d{1,3}(?:,\d{3})*(?:\.\d+)?/gi,
+    // "£47 over"
+    /[£$€]\d{1,3}(?:,\d{3})*(?:\.\d+)?\s+over\b/g,
+    // "over £47" / "over by £47"
+    /\bover\s+(?:by\s+)?[£$€]\d{1,3}(?:,\d{3})*(?:\.\d+)?/gi,
+    // "(~18% over)" — parenthetical warning
+    /\(~?\d+(?:\.\d+)?%\s+over\)/g,
+    // bare "Overspent" / "Exceeded" as a standalone keyword
+    /\b(?:Overspent|Exceeded)\b/g,
+  ];
+  for (const re of WARN_PATTERNS) {
+    out = out.replace(re, stash);
+  }
+
+  // ATX headings on their own line. We only support H1-H3 because Claude
+  // rarely goes deeper and treating deeper levels the same as H3 adds
+  // noise. Render as bold — ANSI has no dedicated "heading" style.
+  out = out.replace(/^\s*#{1,3}\s+(.+?)\s*$/gm, (_, inner: string) => pc.bold(inner));
+
+  // Bold: **text** and __text__. Lazy match so adjacent bolds on one
+  // line (`**a** and **b**`) render as two separate bolds rather than
+  // one span covering everything between the first and last pair.
+  out = out.replace(/\*\*(.+?)\*\*/gs, (_, inner: string) => pc.bold(inner));
+  out = out.replace(/__(.+?)__/g, (_, inner: string) => pc.bold(inner));
+
+  // Inline code: single backticks. Cyan so it doesn't fight the bold
+  // style already used for emphasis.
+  out = out.replace(/`([^`\n]+)`/g, (_, inner: string) => pc.cyan(inner));
+
+  // Bullet lists: leading `- ` or `* ` (with optional indent) → `• `.
+  out = out.replace(/^(\s*)[-*]\s+/gm, '$1• ');
+
+  // Currency amounts: £, $, € followed by a number. Yellow so numbers
+  // pop for quick scanning. Runs after bold so amounts inside bold
+  // spans inherit both styles (ANSI codes nest harmlessly because
+  // yellow's close — `\x1b[39m` — restores fg color only, leaving
+  // bold attribute intact).
+  out = out.replace(/([£$€])(\d{1,3}(?:,\d{3})*(?:\.\d+)?)/g, (_, sym: string, num: string) =>
+    pc.yellow(`${sym}${num}`),
+  );
+
+  // Dim parentheticals that are purely secondary metadata like
+  // "(2 visits)", "(3 transactions)", "(today)". Skip any parens that
+  // still contain a currency glyph (kept vivid for numeric scanning)
+  // or a placeholder marker (warnings already styled). This runs after
+  // the currency pass, so we detect ANSI-wrapped £/€/$ spans by
+  // inspecting for the raw glyph in the captured inner text.
+  out = out.replace(/\(([^)\n]+)\)/g, (match, inner: string) => {
+    if (/[£$€]/.test(inner) || inner.includes(SENTINEL)) return match;
+    return pc.dim(match);
+  });
+
+  // Re-inject warnings in red LAST. Wrapping the full phrase (not the
+  // amount only) matches the marketing mock, where "£47 over" is red
+  // in its entirety rather than splitting into yellow+red.
+  const warnRe = new RegExp(`${SENTINEL}W(\\d+)${SENTINEL}`, 'g');
+  out = out.replace(warnRe, (_, i: string) => pc.red(warnings[Number.parseInt(i, 10)] ?? ''));
+
+  return out;
+}

--- a/src/services/ask.ts
+++ b/src/services/ask.ts
@@ -162,13 +162,18 @@ export async function* runAsk(opts: RunAskOptions): AsyncIterable<AskEvent> {
 
   let iterations = 0;
   let lastStopReason: ClaudeMessageResponse['stop_reason'] = null;
-  // Track the tail of the most recent text we yielded so we can inject
-  // a paragraph break at iteration boundaries. Without this, narration
+  // Track how the most recent yielded text ended so we can inject a
+  // paragraph break at iteration boundaries. Without this, narration
   // from one turn ("…latest month is March 2026.") and the next
   // turn's answer ("Eating Out — March 2026:") run together with no
   // whitespace, since Claude does not repeat the separator it assumes
-  // the chat UI will render.
-  let lastYieldedTextTail = '';
+  // the chat UI will render. We store two booleans derived from
+  // endsWith() rather than a sliced tail so emoji-terminated text
+  // (Claude often closes with 🚨/✅) can't split a UTF-16 surrogate
+  // pair mid-boundary.
+  let hasYieldedText = false;
+  let lastYieldedEndsWithDoubleNewline = false;
+  let lastYieldedEndsWithSingleNewline = false;
 
   while (iterations < maxIterations) {
     if (opts.abortSignal?.aborted) {
@@ -219,17 +224,16 @@ export async function* runAsk(opts: RunAskOptions): AsyncIterable<AskEvent> {
         // text un-terminated and this turn is emitting more text.
         // Only on the first text block of a new turn — blocks within
         // one turn are consecutive sentences that belong together.
-        if (
-          firstTextInTurn &&
-          lastYieldedTextTail.length > 0 &&
-          !/\n\n$/.test(lastYieldedTextTail)
-        ) {
-          const sep = lastYieldedTextTail.endsWith('\n') ? '\n' : '\n\n';
+        if (firstTextInTurn && hasYieldedText && !lastYieldedEndsWithDoubleNewline) {
+          const sep = lastYieldedEndsWithSingleNewline ? '\n' : '\n\n';
           yield { type: 'token', text: sep };
-          lastYieldedTextTail = sep;
+          lastYieldedEndsWithDoubleNewline = true;
+          lastYieldedEndsWithSingleNewline = true;
         }
         yield { type: 'token', text: block.text };
-        lastYieldedTextTail = block.text.slice(-2);
+        hasYieldedText = true;
+        lastYieldedEndsWithDoubleNewline = block.text.endsWith('\n\n');
+        lastYieldedEndsWithSingleNewline = block.text.endsWith('\n');
         firstTextInTurn = false;
       } else if (block.type === 'tool_use') {
         toolUseBlocks.push(block);

--- a/src/services/ask.ts
+++ b/src/services/ask.ts
@@ -162,6 +162,13 @@ export async function* runAsk(opts: RunAskOptions): AsyncIterable<AskEvent> {
 
   let iterations = 0;
   let lastStopReason: ClaudeMessageResponse['stop_reason'] = null;
+  // Track the tail of the most recent text we yielded so we can inject
+  // a paragraph break at iteration boundaries. Without this, narration
+  // from one turn ("…latest month is March 2026.") and the next
+  // turn's answer ("Eating Out — March 2026:") run together with no
+  // whitespace, since Claude does not repeat the separator it assumes
+  // the chat UI will render.
+  let lastYieldedTextTail = '';
 
   while (iterations < maxIterations) {
     if (opts.abortSignal?.aborted) {
@@ -204,10 +211,26 @@ export async function* runAsk(opts: RunAskOptions): AsyncIterable<AskEvent> {
     // tool calls — even tool_use turns can include narrating text.
     const textBlocks: string[] = [];
     const toolUseBlocks: Array<Extract<ClaudeContentBlock, { type: 'tool_use' }>> = [];
+    let firstTextInTurn = true;
     for (const block of resp.content) {
       if (block.type === 'text' && block.text.length > 0) {
         textBlocks.push(block.text);
+        // Inject a paragraph break when the previous iteration left
+        // text un-terminated and this turn is emitting more text.
+        // Only on the first text block of a new turn — blocks within
+        // one turn are consecutive sentences that belong together.
+        if (
+          firstTextInTurn &&
+          lastYieldedTextTail.length > 0 &&
+          !/\n\n$/.test(lastYieldedTextTail)
+        ) {
+          const sep = lastYieldedTextTail.endsWith('\n') ? '\n' : '\n\n';
+          yield { type: 'token', text: sep };
+          lastYieldedTextTail = sep;
+        }
         yield { type: 'token', text: block.text };
+        lastYieldedTextTail = block.text.slice(-2);
+        firstTextInTurn = false;
       } else if (block.type === 'tool_use') {
         toolUseBlocks.push(block);
       }

--- a/tests/unit/ask-tool-loop.test.ts
+++ b/tests/unit/ask-tool-loop.test.ts
@@ -177,9 +177,12 @@ describe('runAsk — tool round trip', () => {
       }),
     );
 
-    // Expect: token, tool_call, tool_result, token, done — in order.
+    // Expect: token, tool_call, tool_result, token (paragraph break
+    // injected between turns), token, done — in order. The separator
+    // ensures narration from the first turn doesn't run straight into
+    // the answer text from the second turn.
     const types = events.map((e) => e.type);
-    expect(types).toEqual(['token', 'tool_call', 'tool_result', 'token', 'done']);
+    expect(types).toEqual(['token', 'tool_call', 'tool_result', 'token', 'token', 'done']);
 
     const call = events.find((e) => e.type === 'tool_call');
     expect(call?.type === 'tool_call' && call.name).toBe('get_account_list');

--- a/tests/unit/markdown-terminal.test.ts
+++ b/tests/unit/markdown-terminal.test.ts
@@ -5,9 +5,12 @@ import { renderMarkdown } from '../../src/lib/markdown-terminal';
 // Strip ANSI escape sequences so assertions on the transformed structure
 // (bullets, headers, currency glyphs) don't depend on color mode. The
 // ESC byte (0x1B) is built from char code to satisfy biome's
-// no-control-characters rule.
+// no-control-characters rule. The pattern accepts multi-parameter SGR
+// sequences (e.g. `ESC[1;33m`) as well as the single-parameter codes
+// picocolors currently emits, so the helper stays robust if the
+// color library ever switches encoding.
 const ESC = String.fromCharCode(0x1b);
-const ANSI_RE = new RegExp(`${ESC}\\[\\d+m`, 'g');
+const ANSI_RE = new RegExp(`${ESC}\\[[\\d;]+m`, 'g');
 function stripAnsi(s: string): string {
   return s.replace(ANSI_RE, '');
 }

--- a/tests/unit/markdown-terminal.test.ts
+++ b/tests/unit/markdown-terminal.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from 'bun:test';
+import pc from 'picocolors';
+import { renderMarkdown } from '../../src/lib/markdown-terminal';
+
+// Strip ANSI escape sequences so assertions on the transformed structure
+// (bullets, headers, currency glyphs) don't depend on color mode. The
+// ESC byte (0x1B) is built from char code to satisfy biome's
+// no-control-characters rule.
+const ESC = String.fromCharCode(0x1b);
+const ANSI_RE = new RegExp(`${ESC}\\[\\d+m`, 'g');
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, '');
+}
+
+// Whether the shared picocolors instance is emitting ANSI codes in
+// this test process. bun:test runs with no TTY by default, so color
+// assertions only run when something upstream (FORCE_COLOR, etc.) has
+// flipped it on. Structural assertions work in both modes.
+const COLORS_ON = pc.isColorSupported;
+
+/**
+ * Assert that `substring` appears in `out` and — when colors are
+ * enabled — is preceded by `ansiOpen`. When colors are disabled, the
+ * ANSI portion is implicitly absent, so we only verify the visible
+ * text survived the transform. Keeps the suite portable across
+ * color-on and color-off environments without leaning on env mutation.
+ */
+function expectStyled(out: string, ansiOpen: string, substring: string): void {
+  expect(stripAnsi(out)).toContain(substring);
+  if (COLORS_ON) {
+    expect(out).toContain(`${ansiOpen}${substring}`);
+  }
+}
+
+describe('renderMarkdown', () => {
+  test('strips **bold** markers from the visible output', () => {
+    const out = renderMarkdown('**Eating Out — March 2026:**');
+    expect(stripAnsi(out)).toBe('Eating Out — March 2026:');
+    expect(out).not.toContain('**');
+  });
+
+  test('strips __bold__ markers too', () => {
+    const out = renderMarkdown('__bold word__');
+    expect(stripAnsi(out)).toBe('bold word');
+  });
+
+  test('renders multiple bolds on one line independently', () => {
+    const out = renderMarkdown('**one** and **two**');
+    expect(stripAnsi(out)).toBe('one and two');
+  });
+
+  test('converts leading dash bullets to •', () => {
+    const out = renderMarkdown('- Spent: £411.85\n- Budget: £350');
+    const stripped = stripAnsi(out);
+    expect(stripped).toContain('• Spent');
+    expect(stripped).toContain('• Budget');
+    expect(stripped).not.toMatch(/^-\s/m);
+  });
+
+  test('converts leading asterisk bullets to •', () => {
+    const out = renderMarkdown('* first\n* second');
+    const stripped = stripAnsi(out);
+    expect(stripped).toContain('• first');
+    expect(stripped).toContain('• second');
+  });
+
+  test('preserves indentation on indented bullets', () => {
+    const out = renderMarkdown('  - nested item');
+    expect(stripAnsi(out)).toBe('  • nested item');
+  });
+
+  test('renders ATX headings without the # prefix', () => {
+    expect(stripAnsi(renderMarkdown('# heading'))).toBe('heading');
+    expect(stripAnsi(renderMarkdown('## heading'))).toBe('heading');
+    expect(stripAnsi(renderMarkdown('### heading'))).toBe('heading');
+  });
+
+  test('renders inline code without backticks', () => {
+    const out = renderMarkdown('use `ferret init` to start');
+    expect(stripAnsi(out)).toBe('use ferret init to start');
+    expect(out).not.toContain('`');
+  });
+
+  test('preserves currency amounts verbatim in visible text', () => {
+    const amounts = ['£411.85', '£350', '£1,234.56', '$99', '€7.50'];
+    for (const amt of amounts) {
+      expect(stripAnsi(renderMarkdown(amt))).toBe(amt);
+    }
+  });
+
+  test('handles a full Claude-style answer end to end', () => {
+    const input = [
+      '**Eating Out — March 2026:**',
+      '- Spent: **£411.85** across 3 transactions',
+      '- Budget: **£350/month**',
+      '- **Overspent by £61.85 (~18% over)**',
+      '',
+      'Driver: the £390.65 at 34 Mayfair on 14 Mar blew the budget.',
+    ].join('\n');
+
+    const out = stripAnsi(renderMarkdown(input));
+    expect(out).not.toContain('**');
+    expect(out).toContain('• Spent: £411.85 across 3 transactions');
+    expect(out).toContain('• Budget: £350/month');
+    expect(out).toContain('• Overspent by £61.85 (~18% over)');
+    expect(out).toContain('Driver: the £390.65 at 34 Mayfair');
+  });
+
+  test('passes through plain text unchanged', () => {
+    const plain = 'You have no accounts yet.';
+    expect(stripAnsi(renderMarkdown(plain))).toBe(plain);
+  });
+
+  // Standard SGR open-codes emitted by picocolors. Tests that rely on
+  // these only assert them when colors are enabled (see expectStyled).
+  const RED_OPEN = `${ESC}[31m`;
+  const YELLOW_OPEN = `${ESC}[33m`;
+  const DIM_OPEN = `${ESC}[2m`;
+
+  describe('warning styling (red)', () => {
+    test('colors "£47 over" entirely red, suppressing currency yellow inside', () => {
+      const out = renderMarkdown('£47 over your £200 budget.');
+      // "£47 over" should be red; "£200" stays yellow.
+      expectStyled(out, RED_OPEN, '£47 over');
+      expectStyled(out, YELLOW_OPEN, '£200');
+      // Stripped text preserves original content verbatim.
+      expect(stripAnsi(out)).toBe('£47 over your £200 budget.');
+    });
+
+    test('colors "Overspent by £61.85" in red', () => {
+      const out = renderMarkdown('Overspent by £61.85 this month');
+      expectStyled(out, RED_OPEN, 'Overspent by £61.85');
+      expect(stripAnsi(out)).toBe('Overspent by £61.85 this month');
+    });
+
+    test('colors "over by £47" in red', () => {
+      const out = renderMarkdown('you went over by £47.');
+      expectStyled(out, RED_OPEN, 'over by £47');
+    });
+
+    test('colors "(~18% over)" parenthetical in red', () => {
+      const out = renderMarkdown('Result: (~18% over) of budget.');
+      expectStyled(out, RED_OPEN, '(~18% over)');
+    });
+
+    test('colors bare "Overspent" keyword in red', () => {
+      const out = renderMarkdown('Overspent this month.');
+      expectStyled(out, RED_OPEN, 'Overspent');
+    });
+  });
+
+  describe('dim parentheticals', () => {
+    test('dims a "(N visits)" parenthetical', () => {
+      const out = renderMarkdown('Dishoom £58 (2 visits)');
+      expectStyled(out, DIM_OPEN, '(2 visits)');
+    });
+
+    test('leaves parentheticals containing currency un-dimmed', () => {
+      const out = renderMarkdown('bought (a £10 coffee) today');
+      // If colors are on, verify no dim wrap opened right at "(a" —
+      // that would mean we incorrectly dimmed a span with currency.
+      if (COLORS_ON) {
+        expect(out).not.toContain(`${DIM_OPEN}(a`);
+      }
+      expectStyled(out, YELLOW_OPEN, '£10');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `ferret ask` default output no longer leaks raw markdown (`**bold**`, `- ` bullets, headings) — tokens are buffered during the tool loop and rendered through a small markdown → ANSI pass when the answer is complete.
- Styling matches the marketing-site demo: currency amounts in yellow, overspend warnings (`£47 over`, `overspent by £X`, `(~18% over)`, bare `Overspent`) in red (takes precedence over yellow), and `(2 visits)`-style parentheticals in dim.
- Non-verbose mode now emits a subtle dim `  … tool_name` line on stderr for each tool call so the user has feedback while Claude runs tools between turns.
- Orchestrator injects a paragraph break between iterations so narration from one turn doesn't concatenate into the next turn's answer (`…data.Hmm,` → `…data.\n\nHmm,`).
- `--json` and `--verbose` paths are unchanged; the JSON payload still carries the raw Claude text so machine consumers aren't affected.

## Visual preview
```
You've spent £247 on Eating Out so far this month, £47 over your £200 budget.

Your pace suggests you'll end at £310.

Biggest contributors:
• Dishoom        £58   (2 visits)
• Pret           £42   (7 visits)
• Franco Manca   £28   (1 visit)
• Kiln           £24   (1 visit)
```
(`£` amounts yellow, `£47 over` red, `(N visits)` dim in a real terminal.)

## Test plan
- [x] `bun test` — all 358 tests pass
- [x] `FORCE_COLOR=1 bun test tests/unit/markdown-terminal.test.ts` — color-specific assertions pass
- [x] `bun run check` — biome clean
- [x] `bun run typecheck` — tsc clean
- [ ] Manual: `ferret ask "did I overspend on eating out this month?"` — confirm rendered output looks like the demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)