### PR TITLE
feat(ask): hide interim narration and collapse repeated tool-call hints

### DIFF
--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -36,7 +36,19 @@ const VERBOSE_PREVIEW_MAX = 240;
 const VERBOSE_PREVIEW_BODY = VERBOSE_PREVIEW_MAX - 3; // "..." suffix budget
 
 interface CollectedAsk {
+  /**
+   * Every text token yielded by the tool loop, concatenated. Includes
+   * interim narration Claude emits between tool calls. Used verbatim
+   * in `--json` mode for backward compatibility.
+   */
   answer: string;
+  /**
+   * Only the tokens from the terminal turn (`isFinal=true`). This is
+   * what default (human) mode renders — intermediate "thinking out
+   * loud" is hidden because it adds noise without carrying the
+   * actual answer.
+   */
+  finalAnswer: string;
   toolsUsed: Array<{ name: string; input: unknown; ok: boolean; summary: string }>;
   iterations: number;
   stopReason: string | null;
@@ -86,6 +98,7 @@ export default defineCommand({
     try {
       const collected: CollectedAsk = {
         answer: '',
+        finalAnswer: '',
         toolsUsed: [],
         iterations: 0,
         stopReason: null,
@@ -105,11 +118,17 @@ export default defineCommand({
       // user is in plain-stream mode; we only echo when verbose is on.
       let pendingCall: { name: string; input: unknown } | null = null;
 
+      // Single-line progress indicator state. We render one dim hint
+      // per tool burst and rewrite it in place on TTY so a 6-call
+      // loop doesn't print 6 duplicate `… query_transactions` lines.
+      const progress: ProgressState = { lastTool: null, count: 0, lineOpen: false };
+
       for await (const event of stream) {
         handleEvent(event, {
           collected,
           wantJson,
           verbose,
+          progress,
           onPendingCall: (e) => {
             pendingCall = e;
           },
@@ -121,6 +140,12 @@ export default defineCommand({
           },
         });
       }
+
+      // If a spinner line is still on screen (no final newline was
+      // emitted because the last tool call was followed only by the
+      // terminating Claude turn), clear it before the rendered answer
+      // lands on stdout — otherwise the answer overwrites the hint.
+      clearProgressLine(progress);
 
       // Audit: one event per ask invocation. Per issue #48 the question
       // text, answer text, and tool inputs/outputs are all omitted — we
@@ -170,10 +195,15 @@ export default defineCommand({
         };
         process.stdout.write(`${formatJson(out)}\n`);
       } else {
-        // Render the buffered markdown answer as ANSI-styled text.
-        // Pass a single trailing newline through so the next shell
-        // prompt lands on its own line.
-        const rendered = renderMarkdown(collected.answer);
+        // Render only the terminal turn's text — Claude's interim
+        // "let me check...", "hmm, let me try...", etc. are interesting
+        // for debugging via --verbose but add noise to the default
+        // output. `finalAnswer` contains only `isFinal=true` tokens.
+        // Fall back to the full buffer if the loop ended without any
+        // final turn (e.g. aborted mid-call) so the user still sees
+        // whatever text Claude managed to produce.
+        const source = collected.finalAnswer.length > 0 ? collected.finalAnswer : collected.answer;
+        const rendered = renderMarkdown(source);
         process.stdout.write(rendered);
         if (!rendered.endsWith('\n')) process.stdout.write('\n');
         if (dedupedProposals.length > 0) {
@@ -191,10 +221,27 @@ export default defineCommand({
   },
 });
 
+/**
+ * State tracked across tool_call events so the non-verbose progress
+ * hint can update a single stderr line in place rather than printing
+ * one dim line per tool call. A 6-query loop now shows
+ * `  … query_transactions (×6)` that increments, not six identical
+ * duplicates.
+ */
+interface ProgressState {
+  /** The tool name currently displayed on the spinner line, or null if none. */
+  lastTool: string | null;
+  /** Run count of the current tool burst. Resets when the tool changes. */
+  count: number;
+  /** Whether a spinner line is currently on screen without a trailing \n. */
+  lineOpen: boolean;
+}
+
 interface HandleEventCtx {
   collected: CollectedAsk;
   wantJson: boolean;
   verbose: boolean;
+  progress: ProgressState;
   onPendingCall: (e: { name: string; input: unknown }) => void;
   consumePendingCall: (ok: boolean, summary: string) => void;
 }
@@ -202,24 +249,30 @@ interface HandleEventCtx {
 function handleEvent(event: AskEvent, ctx: HandleEventCtx): void {
   switch (event.type) {
     case 'token': {
-      // Buffer only — the final answer is rendered as markdown once
-      // the loop completes so users don't see raw `**bold**` syntax
-      // flickering past.
+      // Always collect into `answer` so `--json` mode preserves the
+      // full transcript. Additionally collect into `finalAnswer` when
+      // the orchestrator flags the token as belonging to the terminal
+      // turn; that's the buffer the default (human) render consumes.
       ctx.collected.answer += event.text;
+      if (event.isFinal) ctx.collected.finalAnswer += event.text;
       break;
     }
     case 'tool_call': {
       ctx.onPendingCall({ name: event.name, input: event.input });
       if (ctx.verbose) {
+        // Verbose mode shows each call individually with full input
+        // preview — the spinner-style dedupe would hide information
+        // the user explicitly asked for.
         consola.info(`tool call: ${event.name} ${safeStringify(event.input)}`);
       } else if (!ctx.wantJson && process.stderr.isTTY) {
-        // Non-verbose default on an interactive terminal: surface a
-        // subtle hint on stderr so the user has feedback during long
-        // tool loops without polluting the stdout answer stream.
-        // Skip when stderr is piped or redirected — consumers of the
-        // error stream (log collectors, CI captures) don't benefit
-        // from a progress ticker and would only see noise.
-        process.stderr.write(picocolors.dim(`  … ${event.name}\n`));
+        // Non-verbose default on an interactive terminal: update a
+        // single-line dim hint on stderr. Repeated calls to the same
+        // tool increment a `(×N)` count rewritten in place so a
+        // 6-query loop reads as one line that climbs, not six
+        // duplicates. Non-TTY consumers (log collectors, CI
+        // captures) get silence here — verbose mode is the channel
+        // for that detail.
+        writeProgress(ctx.progress, event.name);
       }
       break;
     }
@@ -240,6 +293,46 @@ function handleEvent(event: AskEvent, ctx: HandleEventCtx): void {
       break;
     }
   }
+}
+
+/**
+ * Emit or update the single-line stderr progress hint. `\r\x1b[K`
+ * is the standard "return to column 0 + erase-to-end-of-line" pair
+ * that lets us overwrite the current terminal line without printing
+ * a new one. The caller only invokes this on a TTY (see
+ * handleEvent) so these escapes always make it to a real terminal.
+ */
+function writeProgress(state: ProgressState, toolName: string): void {
+  if (state.lastTool === toolName) {
+    state.count += 1;
+  } else {
+    // New tool — if a previous spinner was on screen, commit it with
+    // a newline so the new one starts on a fresh line. Each tool
+    // burst thus occupies its own line while repeats within a burst
+    // update in place.
+    if (state.lineOpen) process.stderr.write('\n');
+    state.lastTool = toolName;
+    state.count = 1;
+  }
+  const label = state.count > 1 ? `${toolName} (×${state.count})` : toolName;
+  process.stderr.write(`\r\x1b[K${picocolors.dim(`  … ${label}`)}`);
+  state.lineOpen = true;
+}
+
+/**
+ * Clear any progress line still on screen (called when the tool loop
+ * finishes). Without this, the dim hint would still be on the last
+ * stderr row when the rendered answer prints to stdout, leaving a
+ * stray `  … query_transactions (×6)` above the answer.
+ */
+function clearProgressLine(state: ProgressState): void {
+  if (!state.lineOpen) return;
+  if (process.stderr.isTTY) {
+    process.stderr.write('\r\x1b[K');
+  } else {
+    process.stderr.write('\n');
+  }
+  state.lineOpen = false;
 }
 
 /**

--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -121,7 +121,7 @@ export default defineCommand({
       // Single-line progress indicator state. We render one dim hint
       // per tool burst and rewrite it in place on TTY so a 6-call
       // loop doesn't print 6 duplicate `… query_transactions` lines.
-      const progress: ProgressState = { lastTool: null, count: 0, lineOpen: false };
+      const progress = newProgressState();
 
       for await (const event of stream) {
         handleEvent(event, {
@@ -226,15 +226,33 @@ export default defineCommand({
  * hint can update a single stderr line in place rather than printing
  * one dim line per tool call. A 6-query loop now shows
  * `  … query_transactions (×6)` that increments, not six identical
- * duplicates.
+ * duplicates. Exported for unit tests — not part of the command's
+ * public contract.
  */
-interface ProgressState {
+export interface ProgressState {
   /** The tool name currently displayed on the spinner line, or null if none. */
   lastTool: string | null;
-  /** Run count of the current tool burst. Resets when the tool changes. */
+  /**
+   * Number of times the current tool has fired in a row, including
+   * the call currently being rendered. `0` is only valid as the
+   * initial state before the first tool call; the very first
+   * `writeProgress` call sets it to 1 (first render: bare label)
+   * and each subsequent same-tool call increments it (renders
+   * with a `(×N)` suffix once N > 1). `newProgressState()` returns
+   * the canonical pre-burst zero.
+   */
   count: number;
   /** Whether a spinner line is currently on screen without a trailing \n. */
   lineOpen: boolean;
+}
+
+/**
+ * Canonical initial value for ProgressState. Exists so tests (and
+ * the one call site in `run()`) don't duplicate the zero-state shape
+ * and can't drift on which fields default to what.
+ */
+export function newProgressState(): ProgressState {
+  return { lastTool: null, count: 0, lineOpen: false };
 }
 
 interface HandleEventCtx {
@@ -301,8 +319,9 @@ function handleEvent(event: AskEvent, ctx: HandleEventCtx): void {
  * that lets us overwrite the current terminal line without printing
  * a new one. The caller only invokes this on a TTY (see
  * handleEvent) so these escapes always make it to a real terminal.
+ * Exported for unit tests.
  */
-function writeProgress(state: ProgressState, toolName: string): void {
+export function writeProgress(state: ProgressState, toolName: string): void {
   if (state.lastTool === toolName) {
     state.count += 1;
   } else {
@@ -323,9 +342,10 @@ function writeProgress(state: ProgressState, toolName: string): void {
  * Clear any progress line still on screen (called when the tool loop
  * finishes). Without this, the dim hint would still be on the last
  * stderr row when the rendered answer prints to stdout, leaving a
- * stray `  … query_transactions (×6)` above the answer.
+ * stray `  … query_transactions (×6)` above the answer. Exported
+ * for unit tests.
  */
-function clearProgressLine(state: ProgressState): void {
+export function clearProgressLine(state: ProgressState): void {
   if (!state.lineOpen) return;
   if (process.stderr.isTTY) {
     process.stderr.write('\r\x1b[K');

--- a/src/services/ask.ts
+++ b/src/services/ask.ts
@@ -59,7 +59,19 @@ export const TOOL_RESULT_MAX_CHARS = 8000;
 export type AskEventType = 'token' | 'tool_call' | 'tool_result' | 'done';
 
 export type AskEvent =
-  | { type: 'token'; text: string }
+  | {
+      type: 'token';
+      text: string;
+      /**
+       * True when this token belongs to the terminal turn (stop_reason
+       * other than `tool_use`) — i.e. the final answer. False when
+       * the token is part of interim narration Claude emits between
+       * tool calls. The CLI uses this to render only the final answer
+       * in default mode while still collecting everything for
+       * `--json` output.
+       */
+      isFinal: boolean;
+    }
   | { type: 'tool_call'; name: string; input: unknown }
   | { type: 'tool_result'; name: string; ok: boolean; summary: string }
   | {
@@ -212,6 +224,13 @@ export async function* runAsk(opts: RunAskOptions): AsyncIterable<AskEvent> {
 
     lastStopReason = resp.stop_reason;
 
+    // `isFinal` is true on this assistant turn's text blocks iff the
+    // loop is about to terminate — i.e. Claude didn't ask for more
+    // tools. Callers use this to distinguish the rendered answer
+    // from the "thinking out loud" narration Claude often emits
+    // between tool calls.
+    const isFinalTurn = resp.stop_reason !== 'tool_use';
+
     // Emit any text content from the assistant turn before processing
     // tool calls — even tool_use turns can include narrating text.
     const textBlocks: string[] = [];
@@ -226,11 +245,14 @@ export async function* runAsk(opts: RunAskOptions): AsyncIterable<AskEvent> {
         // one turn are consecutive sentences that belong together.
         if (firstTextInTurn && hasYieldedText && !lastYieldedEndsWithDoubleNewline) {
           const sep = lastYieldedEndsWithSingleNewline ? '\n' : '\n\n';
-          yield { type: 'token', text: sep };
+          // The separator inherits the same isFinal flag as the text
+          // that triggered it so the CLI can keep it with the final
+          // answer rather than dropping it along with interim narration.
+          yield { type: 'token', text: sep, isFinal: isFinalTurn };
           lastYieldedEndsWithDoubleNewline = true;
           lastYieldedEndsWithSingleNewline = true;
         }
-        yield { type: 'token', text: block.text };
+        yield { type: 'token', text: block.text, isFinal: isFinalTurn };
         hasYieldedText = true;
         lastYieldedEndsWithDoubleNewline = block.text.endsWith('\n\n');
         lastYieldedEndsWithSingleNewline = block.text.endsWith('\n');

--- a/tests/unit/ask-progress.test.ts
+++ b/tests/unit/ask-progress.test.ts
@@ -1,0 +1,149 @@
+// Tests for the progress-spinner helpers in src/commands/ask.ts.
+// These guard the behavior the marketing mock depends on:
+//   - one updating line per tool-name burst (not one line per call)
+//   - switching tools commits the current line with a newline and
+//     starts a fresh one
+//   - the lingering line is cleaned up at end-of-loop so the rendered
+//     answer doesn't land on top of a stray hint
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { clearProgressLine, newProgressState, writeProgress } from '../../src/commands/ask';
+
+// Capture stderr writes so we can assert on the escape sequences
+// writeProgress / clearProgressLine emit without painting a real
+// terminal. The helpers only ever write to stderr, so restoring the
+// real writer in afterEach is sufficient cleanup.
+const realStderrWrite = process.stderr.write.bind(process.stderr);
+let chunks: string[];
+
+function captureStderr(): void {
+  chunks = [];
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+    return true;
+  }) as typeof process.stderr.write;
+}
+
+function restoreStderr(): void {
+  process.stderr.write = realStderrWrite;
+}
+
+// ESC byte built from char code to satisfy biome's no-control-in-regex
+// rule. `\r\x1b[K` is the line-clear sequence writeProgress emits.
+const ESC = String.fromCharCode(0x1b);
+const LINE_CLEAR = `\r${ESC}[K`;
+
+describe('newProgressState', () => {
+  test('starts with no active tool, zero count, and no open line', () => {
+    expect(newProgressState()).toEqual({ lastTool: null, count: 0, lineOpen: false });
+  });
+});
+
+describe('writeProgress', () => {
+  beforeEach(captureStderr);
+  afterEach(restoreStderr);
+
+  test('first call of a burst renders the bare tool name, no count suffix', () => {
+    const s = newProgressState();
+    writeProgress(s, 'query_transactions');
+    const out = chunks.join('');
+    expect(out.startsWith(LINE_CLEAR)).toBe(true);
+    expect(out).toContain('query_transactions');
+    expect(out).not.toContain('(×');
+    expect(s.lastTool).toBe('query_transactions');
+    expect(s.count).toBe(1);
+    expect(s.lineOpen).toBe(true);
+  });
+
+  test('repeated same-tool calls increment count and render (×N) in place', () => {
+    const s = newProgressState();
+    writeProgress(s, 'query_transactions');
+    writeProgress(s, 'query_transactions');
+    writeProgress(s, 'query_transactions');
+    // Three calls, count=3, no newline committed between them.
+    expect(s.count).toBe(3);
+    const out = chunks.join('');
+    // The third write should include the (×3) suffix.
+    expect(out).toContain('(×3)');
+    // Each render starts with a line-clear — that's how we overwrite
+    // the previous label without emitting extra rows.
+    const clearCount = out.split(LINE_CLEAR).length - 1;
+    expect(clearCount).toBe(3);
+    // No line-commit newline while the tool name stays the same.
+    expect(out).not.toContain('\n');
+  });
+
+  test('switching tools commits the current line with \\n and resets count', () => {
+    const s = newProgressState();
+    writeProgress(s, 'query_transactions');
+    writeProgress(s, 'query_transactions'); // count = 2
+    writeProgress(s, 'get_category_summary');
+    expect(s.lastTool).toBe('get_category_summary');
+    expect(s.count).toBe(1);
+    const out = chunks.join('');
+    // A single committing newline between the two bursts.
+    expect(out.split('\n')).toHaveLength(2);
+    // The new line ends in a fresh label without a count suffix.
+    const afterNewline = out.split('\n')[1] ?? '';
+    expect(afterNewline).toContain('get_category_summary');
+    expect(afterNewline).not.toContain('(×');
+  });
+});
+
+describe('clearProgressLine', () => {
+  beforeEach(captureStderr);
+  afterEach(restoreStderr);
+
+  test('is a no-op when no line is open', () => {
+    const s = newProgressState();
+    clearProgressLine(s);
+    expect(chunks.join('')).toBe('');
+    expect(s.lineOpen).toBe(false);
+  });
+
+  test('clears the open line with \\r\\x1b[K when stderr is a TTY', () => {
+    const s = newProgressState();
+    writeProgress(s, 'query_transactions');
+    // Force the isTTY branch — test runners normally expose false here.
+    const prevIsTTY = process.stderr.isTTY;
+    Object.defineProperty(process.stderr, 'isTTY', { value: true, configurable: true });
+    try {
+      chunks = [];
+      clearProgressLine(s);
+    } finally {
+      Object.defineProperty(process.stderr, 'isTTY', { value: prevIsTTY, configurable: true });
+    }
+    expect(chunks.join('')).toBe(LINE_CLEAR);
+    expect(s.lineOpen).toBe(false);
+  });
+
+  test('falls back to a plain \\n when stderr is not a TTY', () => {
+    const s = newProgressState();
+    writeProgress(s, 'query_transactions');
+    // Force the non-TTY branch explicitly so the test is independent
+    // of however bun:test initialises process.stderr.isTTY.
+    const prevIsTTY = process.stderr.isTTY;
+    Object.defineProperty(process.stderr, 'isTTY', { value: false, configurable: true });
+    try {
+      chunks = [];
+      clearProgressLine(s);
+    } finally {
+      Object.defineProperty(process.stderr, 'isTTY', { value: prevIsTTY, configurable: true });
+    }
+    expect(chunks.join('')).toBe('\n');
+    expect(s.lineOpen).toBe(false);
+  });
+
+  test('is idempotent — second call writes nothing', () => {
+    const s = newProgressState();
+    writeProgress(s, 'query_transactions');
+    chunks = [];
+    clearProgressLine(s);
+    const firstCall = chunks.join('');
+    chunks = [];
+    clearProgressLine(s);
+    expect(chunks.join('')).toBe('');
+    // First call did emit something; the second is the no-op.
+    expect(firstCall.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/ask-tool-loop.test.ts
+++ b/tests/unit/ask-tool-loop.test.ts
@@ -100,7 +100,7 @@ describe('runAsk — happy path', () => {
     );
     expect(calls).toHaveLength(1);
     const tokens = events.filter((e) => e.type === 'token');
-    expect(tokens).toEqual([{ type: 'token', text: 'hello world' }]);
+    expect(tokens).toEqual([{ type: 'token', text: 'hello world', isFinal: true }]);
     const done = events.find((e) => e.type === 'done');
     expect(done?.type).toBe('done');
     if (done?.type === 'done') {
@@ -183,6 +183,17 @@ describe('runAsk — tool round trip', () => {
     // the answer text from the second turn.
     const types = events.map((e) => e.type);
     expect(types).toEqual(['token', 'tool_call', 'tool_result', 'token', 'token', 'done']);
+
+    // isFinal labeling — interim narration (the first text block,
+    // part of the tool_use turn) is marked non-final so the CLI can
+    // hide it; the terminal turn's text is final. The paragraph
+    // separator between turns inherits the incoming turn's isFinal
+    // so it stays attached to the final answer rather than getting
+    // dropped with the interim narration.
+    const tokens = events.filter((e) => e.type === 'token');
+    expect(tokens[0]).toMatchObject({ text: 'looking up accounts...', isFinal: false });
+    expect(tokens[1]).toMatchObject({ isFinal: true }); // paragraph separator
+    expect(tokens[2]).toMatchObject({ text: 'You have 2 accounts.', isFinal: true });
 
     const call = events.find((e) => e.type === 'tool_call');
     expect(call?.type === 'tool_call' && call.name).toBe('get_account_list');


### PR DESCRIPTION
## Problem

On longer tool loops, `ferret ask` leaks two kinds of noise:

```
  … query_transactions
  … query_transactions
  … query_transactions
  … query_transactions
  … query_transactions
  … query_transactions
I'll check your coffee-related spending for last quarter.

Last quarter = Q1 2026 (Jan 1 – Mar 31, 2026). Let me search for coffee spending.

No coffee-related transactions found in Q1 2026. Let me double-check by looking at a broader view…

Data runs through April 2026, so Q1 2026 is covered. Let me check if there are any coffee-adjacent merchants I might have missed.

£0 on coffee in Q1 2026 (Jan–Mar).
```

- Six identical `… query_transactions` hints on stderr (one per tool call).
- Multiple paragraphs of Claude's "thinking out loud" narration on stdout before the actual answer.

## Summary

Two changes:

1. **Hide interim narration.** `runAsk` now tags each `token` event with `isFinal: boolean`. Tokens from a `stop_reason: 'tool_use'` turn are `isFinal: false` (interim narration between tool calls); tokens from the terminal turn are `isFinal: true`. The CLI renders only the `finalAnswer` buffer in default mode. `--json` keeps the full transcript in `answer` for backward compatibility, so machine consumers are unaffected. `--verbose` keeps its detailed per-tool echo.
2. **Collapse repeated tool hints.** A single-line stderr spinner now rewrites in place with a `(×N)` counter when the same tool fires repeatedly. Switching tools commits the current line and starts a fresh one. Uses the standard `\r\x1b[K` TTY erase sequence; non-TTY stderr stays silent.

## After

```
  … query_transactions (×6)
  … get_category_summary
£0 on coffee in Q1 2026 (Jan–Mar).
```

Paragraph separators between turns already kept the `isFinal` flag of the incoming text, so dropping interim narration doesn't swallow any legitimate content.

## Test plan
- [x] `ask-tool-loop.test.ts` — asserts `isFinal: true` on the single-turn case; new assertion that interim narration from a `tool_use` turn is tagged `isFinal: false` while the terminal turn's text is `true`.
- [x] `bun test` — all 386 tests pass (the one pre-existing flaky ask-cmd test relies on an empty OS keychain and is `ciSkip`-annotated).
- [x] `bun run check`, `bun run typecheck` clean.
- [x] Smoke test with a mock multi-tool loop: 3× `query_transactions` collapses to `(×3)`, switch to `get_category_summary` starts a fresh line, narration hidden, final answer renders cleanly.
- [ ] Manual: `ferret ask "how much did I spend on coffee last quarter?"` — confirm single updating progress line + answer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)