### PR TITLE
fix(cli): preserve typed exit codes + oauth cancel UX

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env bun
-import { defineCommand, runMain } from 'citty';
+import { defineCommand, runCommand, runMain } from 'citty';
 import pkg from '../package.json' with { type: 'json' };
 import { subCommands } from './commands';
 import { loadFerretEnv } from './lib/env-file';
-import { FerretError } from './lib/errors';
+import { FerretError, OAuthCancelledError } from './lib/errors';
 
 loadFerretEnv();
 
@@ -16,10 +16,35 @@ const main = defineCommand({
   subCommands,
 });
 
-runMain(main).catch((err: unknown) => {
+// citty's runMain wraps runCommand in a try/catch that calls
+// `console.error(error, "\n")` and forces exit code 1 — which both destroys
+// our typed exit codes and drops Bun's rich error format (source snippets,
+// enumerable fields) into the terminal. Route command execution through
+// runCommand directly so we can format FerretErrors ourselves; only fall back
+// to runMain for --help / --version since they rely on citty's showUsage
+// resolver.
+const rawArgs = process.argv.slice(2);
+const HELP_FLAGS = new Set(['--help', '-h']);
+const isHelp = rawArgs.some((a) => HELP_FLAGS.has(a));
+const isVersion = rawArgs.length === 1 && (rawArgs[0] === '--version' || rawArgs[0] === '-v');
+
+const execute = isHelp || isVersion ? runMain(main, { rawArgs }) : runCommand(main, { rawArgs });
+
+Promise.resolve(execute).catch((err: unknown) => {
+  if (err instanceof OAuthCancelledError) {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(err.exitCode);
+  }
   if (err instanceof FerretError) {
     process.stderr.write(`${err.name}: ${err.message}\n`);
     process.exit(err.exitCode);
+  }
+  // citty CLIError carries an E_* code; surface the message without the
+  // rich-error dump.
+  const e = err as { code?: unknown; message?: unknown };
+  if (e && typeof e.code === 'string' && e.code.startsWith('E_')) {
+    process.stderr.write(`${String(e.message ?? 'Unknown CLI error')}\n`);
+    process.exit(1);
   }
   process.stderr.write(`${(err as Error).stack ?? String(err)}\n`);
   process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,19 +24,18 @@ const main = defineCommand({
 // to runMain for --help / --version since they rely on citty's showUsage
 // resolver.
 const rawArgs = process.argv.slice(2);
-const HELP_FLAGS = new Set(['--help', '-h']);
-const isHelp = rawArgs.some((a) => HELP_FLAGS.has(a));
-const isVersion = rawArgs.length === 1 && (rawArgs[0] === '--version' || rawArgs[0] === '-v');
+const META_FLAGS = new Set(['--help', '-h', '--version', '-v']);
+const isMetaInvocation = rawArgs.some((a) => META_FLAGS.has(a));
 
-const execute = isHelp || isVersion ? runMain(main, { rawArgs }) : runCommand(main, { rawArgs });
+const execute = isMetaInvocation ? runMain(main, { rawArgs }) : runCommand(main, { rawArgs });
 
 Promise.resolve(execute).catch((err: unknown) => {
-  if (err instanceof OAuthCancelledError) {
-    process.stderr.write(`${err.message}\n`);
-    process.exit(err.exitCode);
-  }
   if (err instanceof FerretError) {
-    process.stderr.write(`${err.name}: ${err.message}\n`);
+    // OAuthCancelledError is user-initiated (hit "Cancel" in browser) so we
+    // render just the message — no class name prefix, no stack. Every other
+    // FerretError keeps the `Name: message` prefix for grep-ability.
+    const body = err instanceof OAuthCancelledError ? err.message : `${err.name}: ${err.message}`;
+    process.stderr.write(`${body}\n`);
     process.exit(err.exitCode);
   }
   // citty CLIError carries an E_* code; surface the message without the

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -16,6 +16,11 @@ export class AuthError extends FerretError {
   override readonly exitCode = 3;
 }
 
+// Signals that the user explicitly cancelled an OAuth flow in the browser
+// (e.g. hit "Cancel" or closed the consent screen). Renders without a stack
+// dump and inherits AuthError's exit code 3 since auth didn't complete.
+export class OAuthCancelledError extends AuthError {}
+
 export class NetworkError extends FerretError {
   override readonly exitCode = 4;
 }

--- a/src/services/oauth.ts
+++ b/src/services/oauth.ts
@@ -12,7 +12,7 @@
 import { randomBytes } from 'node:crypto';
 import { platform } from 'node:os';
 import ferretSvgRaw from '../ferret.svg' with { type: 'text' };
-import { AuthError, NetworkError } from '../lib/errors';
+import { AuthError, NetworkError, OAuthCancelledError } from '../lib/errors';
 
 export const PORT_MIN = 8000;
 export const PORT_MAX = 9999;
@@ -84,27 +84,62 @@ p{margin:0;color:#9a9a9a;font-size:14px;line-height:1.5;}
 <script>setTimeout(()=>{try{window.close();}catch(e){}},2500);</script>
 </body></html>`;
 
-const ERROR_HTML = (msg: string): string =>
-  `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>ferret — error</title>
+interface ErrorPageOpts {
+  title: string;
+  badge: string;
+  badgeColor: 'red' | 'amber';
+  heading: string;
+  message: string;
+  hint: string;
+}
+
+const ERROR_PAGE = (opts: ErrorPageOpts): string => {
+  const tone =
+    opts.badgeColor === 'amber'
+      ? 'background:rgba(245,158,11,.1);border:1px solid rgba(245,158,11,.3);color:#fbbf24;'
+      : 'background:rgba(239,68,68,.1);border:1px solid rgba(239,68,68,.3);color:#f87171;';
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>ferret — ${escapeHtml(opts.title)}</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <style>
 :root{color-scheme:dark;}
+*{box-sizing:border-box;}
 body{font-family:-apple-system,BlinkMacSystemFont,'Inter',sans-serif;background:radial-gradient(ellipse at top,#161616 0%,#0a0a0a 60%);color:#eaeaea;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;padding:24px;}
-.card{max-width:420px;width:100%;padding:40px 32px;background:#111;border:1px solid #222;border-radius:16px;text-align:center;}
+.card{max-width:420px;width:100%;padding:40px 32px;background:#111;border:1px solid #222;border-radius:16px;text-align:center;box-shadow:0 10px 40px rgba(0,0,0,.4);}
 .logo{margin:0 auto 20px;display:flex;align-items:center;justify-content:center;color:#f97316;}
-.logo svg{width:56px;height:auto;}
-.badge{display:inline-flex;align-items:center;gap:8px;padding:4px 12px;border-radius:999px;background:rgba(239,68,68,.1);border:1px solid rgba(239,68,68,.3);color:#f87171;font-size:12px;font-weight:500;margin-bottom:16px;}
-h1{margin:0 0 10px;font-size:20px;font-weight:600;}
+.logo svg{width:56px;height:auto;filter:drop-shadow(0 4px 12px rgba(249,115,22,.25));}
+.badge{display:inline-flex;align-items:center;gap:8px;padding:4px 12px;border-radius:999px;${tone}font-size:12px;font-weight:500;margin-bottom:16px;}
+h1{margin:0 0 10px;font-size:22px;font-weight:600;letter-spacing:-.01em;}
 p{margin:0;color:#9a9a9a;font-size:14px;line-height:1.5;word-break:break-word;}
 .hint{margin-top:20px;font-size:12px;color:#666;}
 </style></head>
 <body><div class="card">
 <div class="logo">${LOGO_SVG}</div>
-<div class="badge">connection failed</div>
-<h1>Something went wrong</h1>
-<p>${escapeHtml(msg)}</p>
-<div class="hint">Return to the terminal for details.</div>
+<div class="badge">${escapeHtml(opts.badge)}</div>
+<h1>${escapeHtml(opts.heading)}</h1>
+<p>${escapeHtml(opts.message)}</p>
+<div class="hint">${escapeHtml(opts.hint)}</div>
 </div></body></html>`;
+};
+
+const CANCELLED_HTML = ERROR_PAGE({
+  title: 'cancelled',
+  badge: 'connection cancelled',
+  badgeColor: 'amber',
+  heading: 'No bank was linked',
+  message:
+    'You cancelled the connection in the browser. You can close this tab and try again anytime.',
+  hint: 'ferret · personal finance CLI',
+});
+
+const ERROR_HTML = (msg: string): string =>
+  ERROR_PAGE({
+    title: 'error',
+    badge: 'connection failed',
+    badgeColor: 'red',
+    heading: 'Something went wrong',
+    message: msg,
+    hint: 'Return to the terminal for details.',
+  });
 
 function escapeHtml(s: string): string {
   return s.replace(/[&<>'"`]/g, (c) => `&#${c.charCodeAt(0)};`);
@@ -144,11 +179,21 @@ function startCallbackServer(
       if (url.pathname !== '/callback') {
         return new Response('Not found', { status: 404 });
       }
+      // Defer all settlements so the response body finishes streaming before
+      // the caller's `finally` tears the server down (mirrors the success
+      // path's microtask defer).
       const error = url.searchParams.get('error');
       const errorDescription = url.searchParams.get('error_description');
       if (error) {
+        if (error === 'access_denied') {
+          queueMicrotask(() => reject(new OAuthCancelledError('Link cancelled in browser.')));
+          return new Response(CANCELLED_HTML, {
+            status: 200,
+            headers: { 'content-type': 'text/html; charset=utf-8' },
+          });
+        }
         const msg = errorDescription ? `${error}: ${errorDescription}` : error;
-        reject(new AuthError(`TrueLayer authorization failed — ${msg}`));
+        queueMicrotask(() => reject(new AuthError(`TrueLayer authorization failed — ${msg}`)));
         return new Response(ERROR_HTML(msg), {
           status: 400,
           headers: { 'content-type': 'text/html; charset=utf-8' },
@@ -157,21 +202,21 @@ function startCallbackServer(
       const code = url.searchParams.get('code');
       const state = url.searchParams.get('state');
       if (!code) {
-        reject(new AuthError('TrueLayer callback missing `code` parameter.'));
+        queueMicrotask(() => reject(new AuthError('TrueLayer callback missing `code` parameter.')));
         return new Response(ERROR_HTML('missing code'), {
           status: 400,
           headers: { 'content-type': 'text/html; charset=utf-8' },
         });
       }
       if (!validateState(expectedState, state)) {
-        reject(new AuthError('OAuth state mismatch — possible CSRF. Aborting.'));
+        queueMicrotask(() =>
+          reject(new AuthError('OAuth state mismatch — possible CSRF. Aborting.')),
+        );
         return new Response(ERROR_HTML('state mismatch'), {
           status: 400,
           headers: { 'content-type': 'text/html; charset=utf-8' },
         });
       }
-      // Defer so the success HTML finishes streaming before the caller's
-      // `finally` tears the server down.
       queueMicrotask(() => resolve({ code, state: state as string }));
       return new Response(SUCCESS_HTML, {
         status: 200,


### PR DESCRIPTION
## Summary
- **CLI error routing** (`src/cli.ts`): route through citty's `runCommand` directly instead of `runMain`, which swallows our typed `FerretError.exitCode` contract and dumps Bun's rich error format (source snippets, enumerable fields). `runMain` is still used for `--help` / `--version` since they rely on citty's `showUsage` resolver. Also surfaces citty `CLIError` (E_*) as a plain message.
- **OAuth cancellation** (`src/services/oauth.ts`, `src/lib/errors.ts`): detect `access_denied` on the callback and reject with a new `OAuthCancelledError` (inherits `AuthError`'s exit 3) plus a dedicated amber-toned cancellation page. Also defers all reject paths via `queueMicrotask` so response bodies finish streaming before the callback server is torn down in `finally`.

## Test plan
- [ ] `bun run src/cli.ts unknown-command` — confirm plain one-line message, exit 1, no Bun rich-error dump
- [ ] `bun run src/cli.ts --help` and `--version` — confirm they still work
- [ ] `bun run src/cli.ts sync` without config — confirm `ConfigError` prints as `ConfigError: …` and exits with its typed code
- [ ] `ferret connect` then click **Cancel** in the TrueLayer browser flow — confirm amber "No bank was linked" page and terminal message without a stack
- [ ] `bun run check && bun run typecheck && bun test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)